### PR TITLE
Cleanup buildscripts, tests, and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Paralithic
+
 Super fast expression evaluator/parser written in Java
 
 Paralithic is a library for parsing and evaluating mathematical expressions. It uses ASM to dynamically
@@ -13,6 +14,7 @@ By directly generating bytecode to be executed by the JVM, and with the above op
 able to achieve about the same speed as hard-coded ones.
 
 ## Usage
+
 ```java
 Parser parser = new Parser(); // Create parser instance.
 Scope scope = new Scope(); // Create variable scope. This scope can hold both constants and invocation variables.
@@ -24,55 +26,97 @@ expression.evaluate(3); // 20 (3*4 + 2^3 = 20)
 
 
 ## Performance
-The expression `"(2 + ((7-5) * (3.14159 * pow(x, (12-10))) + sin(-3.141)))"` was evaluated
-with x ranging from 0 to 1,000,000 in 3 different expression libraries.
 
-The test was run 20 times to allow the JIT to warmup and optimize as much as possible,
-then 20 more iterations were timed and averaged.
-The "Aggregate" values are the summed values of all iterations in the test. The aggregate is mainly
-to prevent HotSpot JIT from optimizing out calls to evaluation altogether.
+The expression `2 + ((7-5) * (3.14159 * pow(x, (12-10))) + sin(-3.141))` was evaluated in 3 different expression libraries.
+
+The test was run for 3 iterations of 1 second each to allow the JIT to warmup and optimize as much as possible,
+the next 3 iterations of 1 second each were timed and averaged.
+This was then repeated 3 times, with a new JVM each time, and the results were averaged.
 
 The `native` and `native (simplified)` tests each tested a hard-coded method containing the expanded
 and simplified expression, respectively.
 
 ```
-Testing native (simplified)...
-Avg for 20 iterations of 1000000 evaluations: 3.754001105263158ms
-Aggregate: 8.377560766985067E19
-
-Testing Paralithic...
-Avg for 20 iterations of 1000000 evaluations: 4.712781315789473ms
-Aggregate: 8.377560766985067E19
-
-Testing native...
-Avg for 20 iterations of 1000000 evaluations: 9.540265526315789ms
-Aggregate: 8.377560766985067E19
-
-Testing parsii...
-Avg for 20 iterations of 1000000 evaluations: 38.82801278947368ms
-Aggregate: 8.377560766985075E19
-
-Testing exp4j...
-Avg for 20 iterations of 1000000 evaluations: 207.5611217368421ms
-Aggregate: 8.377560766985067E19
+Benchmark                                             (testExpression)  (input)  Mode  Cnt    Score    Error  Units
+exp4J                2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9  232.925 ± 13.574  ns/op
+native               2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9   25.687 ±  1.095  ns/op
+parsii               2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9   24.371 ±  0.894  ns/op
+Paralithic           2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9    3.387 ±  0.887  ns/op
+native (simplified)  2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9    2.906 ±  0.126  ns/op
 ```
-Results are from test run on an AMD Ryzen 9 3900X.
 
-Paralithic generated the following class from the input function (decompiled with FernFlower):
+Results are from tests run on an AMD Ryzen 5 3600.
+
+<details>
+<summary>Full Benchmark Results</summary>
+
+```
+Benchmark                                                                     (testExpression)  (input)  Mode  Cnt    Score    Error  Units
+PerformanceTest.exp4JPerformance                                                             2        1  avgt    9   28.913 ±  3.445  ns/op
+PerformanceTest.exp4JPerformance                                                             2     1000  avgt    9   28.767 ±  2.215  ns/op
+PerformanceTest.exp4JPerformance                                                             2    23422  avgt    9   26.696 ±  1.242  ns/op
+PerformanceTest.exp4JPerformance                                               2 + 3.14159 * x        1  avgt    9   49.046 ±  3.008  ns/op
+PerformanceTest.exp4JPerformance                                               2 + 3.14159 * x     1000  avgt    9   54.834 ± 17.179  ns/op
+PerformanceTest.exp4JPerformance                                               2 + 3.14159 * x    23422  avgt    9   50.308 ±  5.501  ns/op
+PerformanceTest.exp4JPerformance             2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9  232.925 ± 13.574  ns/op
+PerformanceTest.exp4JPerformance             2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))     1000  avgt    9  238.926 ± 23.293  ns/op
+PerformanceTest.exp4JPerformance             2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))    23422  avgt    9  239.316 ± 26.309  ns/op
+PerformanceTest.nativePerformance                                                            2        1  avgt    9   25.070 ±  0.453  ns/op
+PerformanceTest.nativePerformance                                                            2     1000  avgt    9   25.297 ±  0.309  ns/op
+PerformanceTest.nativePerformance                                                            2    23422  avgt    9   25.619 ±  1.581  ns/op
+PerformanceTest.nativePerformance                                              2 + 3.14159 * x        1  avgt    9   25.227 ±  0.433  ns/op
+PerformanceTest.nativePerformance                                              2 + 3.14159 * x     1000  avgt    9   25.551 ±  1.514  ns/op
+PerformanceTest.nativePerformance                                              2 + 3.14159 * x    23422  avgt    9   24.988 ±  0.341  ns/op
+PerformanceTest.nativePerformance            2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9   25.687 ±  1.095  ns/op
+PerformanceTest.nativePerformance            2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))     1000  avgt    9   25.863 ±  1.797  ns/op
+PerformanceTest.nativePerformance            2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))    23422  avgt    9   24.934 ±  0.266  ns/op
+PerformanceTest.nativePerformanceSimplified                                                  2        1  avgt    9    2.870 ±  0.063  ns/op
+PerformanceTest.nativePerformanceSimplified                                                  2     1000  avgt    9    2.934 ±  0.238  ns/op
+PerformanceTest.nativePerformanceSimplified                                                  2    23422  avgt    9    2.892 ±  0.108  ns/op
+PerformanceTest.nativePerformanceSimplified                                    2 + 3.14159 * x        1  avgt    9    2.933 ±  0.126  ns/op
+PerformanceTest.nativePerformanceSimplified                                    2 + 3.14159 * x     1000  avgt    9    2.880 ±  0.043  ns/op
+PerformanceTest.nativePerformanceSimplified                                    2 + 3.14159 * x    23422  avgt    9    2.950 ±  0.214  ns/op
+PerformanceTest.nativePerformanceSimplified  2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9    2.906 ±  0.126  ns/op
+PerformanceTest.nativePerformanceSimplified  2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))     1000  avgt    9    2.937 ±  0.297  ns/op
+PerformanceTest.nativePerformanceSimplified  2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))    23422  avgt    9    2.900 ±  0.115  ns/op
+PerformanceTest.paralithicPerformance                                                        2        1  avgt    9    6.478 ±  0.203  ns/op
+PerformanceTest.paralithicPerformance                                                        2     1000  avgt    9    6.435 ±  0.221  ns/op
+PerformanceTest.paralithicPerformance                                                        2    23422  avgt    9    6.503 ±  0.139  ns/op
+PerformanceTest.paralithicPerformance                                          2 + 3.14159 * x        1  avgt    9    1.041 ±  0.012  ns/op
+PerformanceTest.paralithicPerformance                                          2 + 3.14159 * x     1000  avgt    9    1.053 ±  0.047  ns/op
+PerformanceTest.paralithicPerformance                                          2 + 3.14159 * x    23422  avgt    9    1.061 ±  0.042  ns/op
+PerformanceTest.paralithicPerformance        2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9    3.387 ±  0.887  ns/op
+PerformanceTest.paralithicPerformance        2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))     1000  avgt    9    3.111 ±  0.150  ns/op
+PerformanceTest.paralithicPerformance        2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))    23422  avgt    9    3.158 ±  0.263  ns/op
+PerformanceTest.parsiiPerformance                                                            2        1  avgt    9    1.407 ±  0.079  ns/op
+PerformanceTest.parsiiPerformance                                                            2     1000  avgt    9    1.401 ±  0.023  ns/op
+PerformanceTest.parsiiPerformance                                                            2    23422  avgt    9    1.410 ±  0.072  ns/op
+PerformanceTest.parsiiPerformance                                              2 + 3.14159 * x        1  avgt    9    5.253 ±  0.400  ns/op
+PerformanceTest.parsiiPerformance                                              2 + 3.14159 * x     1000  avgt    9    5.170 ±  0.380  ns/op
+PerformanceTest.parsiiPerformance                                              2 + 3.14159 * x    23422  avgt    9    5.130 ±  0.119  ns/op
+PerformanceTest.parsiiPerformance            2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))        1  avgt    9   24.371 ±  0.894  ns/op
+PerformanceTest.parsiiPerformance            2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))     1000  avgt    9   24.020 ±  0.765  ns/op
+PerformanceTest.parsiiPerformance            2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))    23422  avgt    9   24.178 ±  1.397  ns/op
+```
+
+</details>
+
+Paralithic generated the following class from the input function
+(decompiled with [Vineflower](https://vineflower.org/), a fork of FernFlower):
 ```java
 public class ExpressionIMPL_0 implements Expression {
     public ExpressionIMPL_0() {
     }
 
     public double evaluate(double[] var1) {
-        return 1.9994073464449005D + 6.28318D * NativeMath.pow2(var1[0]);
+        return 1.9994073464449005 + 6.28318 * NativeMath.intPow(var2[0], 4.0);
     }
 }
 ```
 
 ## License
-Paralithic is licensed under the 
-[GNU General Public License version 3.0](https://github.com/PolyhedralDev/Paralithic/blob/master/LICENSE) (GPLv3).
+
+Paralithic is licensed under the [MIT License](https://github.com/PolyhedralDev/Paralithic/blob/master/LICENSE).
 
 Paralithic is a "fork" of a [modified version](https://github.com/PolyhedralDev/parsii) of
 [Parsii](https://github.com/scireum/parsii), licensed under the [MIT license](https://github.com/scireum/parsii/blob/develop/LICENSE).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,12 @@ nyx {
         buildDependsOnJar = true
 
         jvmTarget = 17
+
+        java {
+            allJavadocWarnings = true
+            noMissingJavadocWarnings = true
+            javadocWarningsAsErrors = true
+        }
     }
 
     publishing {
@@ -88,10 +94,11 @@ class Version(val major: String, val minor: String, val revision: String, val pr
     override fun toString(): String {
         return if (!preRelease)
             "$major.$minor.$revision"
-        else //Only use git hash if it's a prerelease.
+        else // Only use git hash if it's a prerelease.
             "$major.$minor.$revision+${getGitHash()}"
     }
 }
+
 fun getGitHash(): String {
     val stdout = ByteArrayOutputStream()
     exec {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,9 +68,15 @@ dependencies {
 
     api(libs.asm)
 
-    testImplementation(libs.junit)
+    testImplementation(libs.bundles.junit)
     jmh(libs.parsii)
     jmh(libs.exp4j)
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
 }
 
 /**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,63 +1,76 @@
+import ca.solostudios.nyx.util.codeMC
 import java.io.ByteArrayOutputStream
 
 plugins {
     `java-library`
     `maven-publish`
-    id("me.champeau.jmh") version "0.7.2"
+
+    alias(libs.plugins.nyx)
+    alias(libs.plugins.jmh)
 }
 
 val versionObj = Version("0", "8", "0", false)
 
+nyx {
+    info {
+        name = "Paralithic"
+        group = "com.dfsek"
+        module = "paralithic"
+        version = "$versionObj"
+        description = """
+            Paralithic is a super fast library for parsing and evaluating mathematical expressions.
+        """.trimIndent()
 
-group = "com.dfsek"
-version = versionObj
+        organizationName = "Polyhedral Development"
+        organizationUrl = "https://github.com/PolyhedralDev/"
 
-repositories {
-    mavenCentral()
-    maven { url = uri("https://repo.codemc.org/repository/maven-public") }
-}
-
-dependencies {
-    implementation("org.jetbrains:annotations:24.0.1")
-
-    api("org.ow2.asm:asm:9.5")
-
-    jmh("com.scireum:parsii:4.0")
-    jmh("net.objecthunter:exp4j:0.4.8")
-    testImplementation("junit:junit:4.13.2")
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}
-
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components["java"])
-        }
+        repository.fromGithub("PolyhedralDev", "Paralithic")
+        license.useMIT()
     }
 
-    repositories {
-        val mavenUrl = "https://repo.codemc.io/repository/maven-releases/"
+    compile {
+        javadocJar = true
+        sourcesJar = true
 
-        maven(mavenUrl) {
-            val mavenUsername: String? by project
-            val mavenPassword: String? by project
-            if (mavenUsername != null && mavenPassword != null) {
-                credentials {
-                    username = mavenUsername
-                    password = mavenPassword
+        allWarnings = true
+        warningsAsErrors = true
+        distributeLicense = true
+        buildDependsOnJar = true
+
+        jvmTarget = 17
+    }
+
+    publishing {
+        withPublish()
+
+        repositories {
+            maven("https://repo.codemc.io/repository/maven-releases/") {
+                credentials(PasswordCredentials::class)
+            }
+
+            maven("https://maven.solo-studios.ca/releases/") {
+                credentials(PasswordCredentials::class)
+                authentication { // publishing doesn't work without this for some reason
+                    create<BasicAuthentication>("basic")
                 }
             }
         }
     }
+}
+
+repositories {
+    mavenCentral()
+    codeMC()
+}
+
+dependencies {
+    implementation(libs.jetbrains.annotations)
+
+    api(libs.asm)
+
+    testImplementation(libs.junit)
+    jmh(libs.parsii)
+    jmh(libs.exp4j)
 }
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ jetbrains-annotations = "24.0.1"
 
 asm = "9.5"
 
-junit = "4.13.2"
+junit-jupiter = "5.10.3"
 
 # For testing
 parsii = "4.0"
@@ -23,9 +23,16 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 
 asm = { group = "org.ow2.asm", name = "asm", version.ref = "asm" }
 
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
+junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit-jupiter" }
 
 parsii = { group = "com.scireum", name = "parsii", version.ref = "parsii" }
 exp4j = { group = "net.objecthunter", name = "exp4j", version.ref = "exp4j" }
 
 [bundles]
+junit = [
+    "junit-jupiter-api",
+    "junit-jupiter-engine",
+    "junit-jupiter-params"
+]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,31 @@
+[versions]
+nyx = "0.2.2"
+jmh = "0.7.2"
+
+jetbrains-annotations = "24.0.1"
+
+asm = "9.5"
+
+junit = "4.13.2"
+
+# For testing
+parsii = "4.0"
+exp4j = "0.4.8"
+
+[plugins]
+
+nyx = { id = "ca.solo-studios.nyx", version.ref = "nyx" }
+
+jmh = { id = "me.champeau.jmh", version.ref = "jmh" }
+
+[libraries]
+jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
+
+asm = { group = "org.ow2.asm", name = "asm", version.ref = "asm" }
+
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+parsii = { group = "com.scireum", name = "parsii", version.ref = "parsii" }
+exp4j = { group = "net.objecthunter", name = "exp4j", version.ref = "exp4j" }
+
+[bundles]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-nyx = "0.2.2"
+nyx = "0.2.3"
 jmh = "0.7.2"
 
 jetbrains-annotations = "24.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/jmh/java/com/dfsek/paralithic/bench/PerformanceTest.java
+++ b/src/jmh/java/com/dfsek/paralithic/bench/PerformanceTest.java
@@ -3,79 +3,104 @@ package com.dfsek.paralithic.bench;
 import com.dfsek.paralithic.Expression;
 import com.dfsek.paralithic.eval.parser.Parser;
 import com.dfsek.paralithic.eval.parser.Scope;
-import com.dfsek.paralithic.eval.tokenizer.ParseException;
 import com.dfsek.paralithic.functions.natives.NativeMath;
 import net.objecthunter.exp4j.ExpressionBuilder;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
 import parsii.eval.Variable;
 
 import java.util.concurrent.TimeUnit;
 
+@Fork(3)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Benchmark)
-@Warmup(iterations = 5, time = 50, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 3, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
 public class PerformanceTest {
-    private static final String TEST = "(2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141)))";
+    static {
+        System.setProperty("paralithic.debug.dump", "true");
+    }
+    private Expression expression;
 
-    Expression expression;
-    parsii.eval.Expression parsiiExpression;
-    Variable x;
-    net.objecthunter.exp4j.Expression expExpression;
+    private Variable parsiiVariable;
 
-    public PerformanceTest() {
+    private parsii.eval.Expression parsiiExpression;
+
+    private net.objecthunter.exp4j.Expression expExpression;
+
+    @Param({"1", "1000", "23422"})
+    private double input;
+
+    @Param("2 + ((7-5) * (3.14159 * x^(14-10)) + sin(-3.141))")
+    private String testExpression;
+
+    @Setup(Level.Trial)
+    public void setup() {
         try {
-            Parser parser = new Parser();
-            Scope scope = new Scope();
-            scope.addInvocationVariable("x");
-            expression = parser.parse(TEST, scope);
-
-            parsii.eval.Scope scope2 = new parsii.eval.Scope();
-            x = scope2.create("x");
-            parsiiExpression = parsii.eval.Parser.parse(TEST, scope2);
-
-            expExpression = new ExpressionBuilder(TEST)
-                    .variable("x")
-                    .build();
+            { // paralithic setup
+                Parser parser = new Parser();
+                Scope scope = new Scope();
+                scope.addInvocationVariable("x");
+                this.expression = parser.parse(this.testExpression, scope);
+            }
+            { // parsii setup
+                parsii.eval.Scope scope2 = new parsii.eval.Scope();
+                this.parsiiVariable = scope2.create("x");
+                this.parsiiExpression = parsii.eval.Parser.parse(this.testExpression, scope2);
+            }
+            { // exp4j setup
+                this.expExpression = new ExpressionBuilder(this.testExpression)
+                        .variable("x")
+                        .build();
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    @Param({"0", "1", "1000", "23422"})
-    double value;
-
     @Benchmark
-    public double paralithicPerformance() {
-        return expression.evaluate(value);
+    public void paralithicPerformance(Blackhole blackhole) {
+        blackhole.consume(this.expression.evaluate(this.input));
     }
 
     @Benchmark
-    public double parsiiPerformance() {
-        x.setValue(value);
-        return parsiiExpression.evaluate();
+    public void parsiiPerformance(Blackhole blackhole) {
+        this.parsiiVariable.setValue(this.input);
+        blackhole.consume(this.parsiiExpression.evaluate());
     }
 
     @Benchmark
-    public double exp4JPerformance() {
-        expExpression.setVariable("x", value);
-        return expExpression.evaluate();
+    public void exp4JPerformance(Blackhole blackhole) {
+        this.expExpression.setVariable("x", this.input);
+        blackhole.consume(this.expExpression.evaluate());
     }
 
     @Benchmark
-    public double nativePerformanceSimplified() {
-        return evaluateNativeSimplified(value);
+    public void nativePerformanceSimplified(Blackhole blackhole) {
+        blackhole.consume(evaluateNativeSimplified(this.input));
     }
 
     @Benchmark
-    public double nativePerformance() {
-        return evaluateNative(value);
+    public void nativePerformance(Blackhole blackhole) {
+        blackhole.consume(evaluateNative(this.input));
     }
 
-    public double evaluateNativeSimplified(double... in) {
+    private static double evaluateNativeSimplified(double... in) {
         return 1.9994073464449005D + 6.28318D * NativeMath.intPow(in[0], 4);
     }
 
-    public double evaluateNative(double... in) {
+    private static double evaluateNative(double... in) {
         return 2.0D + (7.0D + -5.0D) * 3.14159D * Math.pow(in[0], 14.0D - 10.0D) + Math.sin(-3.141D);
     }
 }

--- a/src/main/java/com/dfsek/paralithic/eval/parser/Parser.java
+++ b/src/main/java/com/dfsek/paralithic/eval/parser/Parser.java
@@ -48,6 +48,7 @@ import java.util.TreeMap;
  * This is a recursive descending parser which has a method per non-terminal.
  * <p>
  * Using this parser is as easy as:
+ * <pre>
  * {@code
  * Scope scope = Scope.create();
  * NamedConstant a = scope.getVariable("a");
@@ -55,8 +56,8 @@ import java.util.TreeMap;
  * a.setValue(4);
  * System.out.println(expr.evaluate());
  * a.setValue(5);
- * System.out.println(expr.evaluate());
- * }
+ * System.out.println(expr.evaluate());}
+ * </pre>
  */
 public class Parser {
 

--- a/src/main/java/com/dfsek/paralithic/eval/parser/Parser.java
+++ b/src/main/java/com/dfsek/paralithic/eval/parser/Parser.java
@@ -22,9 +22,9 @@ import com.dfsek.paralithic.functions.natives.NativeMath;
 import com.dfsek.paralithic.functions.node.NodeFunction;
 import com.dfsek.paralithic.functions.node.TernaryIfFunction;
 import com.dfsek.paralithic.node.Constant;
-import com.dfsek.paralithic.node.special.InvocationVariableNode;
 import com.dfsek.paralithic.node.Node;
 import com.dfsek.paralithic.node.binary.BinaryNode;
+import com.dfsek.paralithic.node.special.InvocationVariableNode;
 import com.dfsek.paralithic.node.special.function.FunctionNode;
 import com.dfsek.paralithic.node.special.function.NativeFunctionNode;
 import com.dfsek.paralithic.node.unary.AbsoluteValueNode;
@@ -32,7 +32,10 @@ import com.dfsek.paralithic.node.unary.NegationNode;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 
 /**
@@ -188,7 +191,7 @@ public class Parser {
     }
 
     /**
-     * Parses the expression in <tt>input</tt>
+     * Parses the expression in {@code input}
      *
      * @return the parsed expression
      * @throws ParseException if the expression contains one or more errors
@@ -240,8 +243,8 @@ public class Parser {
     /**
      * Parser rule for parsing an expression.
      * <p>
-     * This is the root rule. An expression is a <tt>relationalExpression</tt> which might be followed by a logical
-     * operator (&amp;&amp; or ||) and another <tt>expression</tt>.
+     * This is the root rule. An expression is a {@code relationalExpression} which might be followed by a logical
+     * operator (&amp;&amp; or ||) and another {@code expression}.
      *
      * @return an expression parsed from the given input
      */
@@ -264,8 +267,8 @@ public class Parser {
     /**
      * Parser rule for parsing a relational expression.
      * <p>
-     * A relational expression is a <tt>term</tt> which might be followed by a relational operator
-     * (&lt;,&lt;=,...,&gt;) and another <tt>relationalExpression</tt>.
+     * A relational expression is a {@code term} which might be followed by a relational operator
+     * (&lt;,&lt;=,...,&gt;) and another {@code relationalExpression}.
      *
      * @return a relational expression parsed from the given input
      */
@@ -307,7 +310,7 @@ public class Parser {
     /**
      * Parser rule for parsing a term.
      * <p>
-     * A term is a <tt>product</tt> which might be followed by + or - as operator and another <tt>term</tt>.
+     * A term is a {@code product} which might be followed by + or - as operator and another {@code term}.
      *
      * @return a term parsed from the given input
      */
@@ -336,7 +339,7 @@ public class Parser {
     /**
      * Parser rule for parsing a product.
      * <p>
-     * A product is a <tt>power</tt> which might be followed by *, / or % as operator and another <tt>product</tt>.
+     * A product is a {@code power} which might be followed by *, / or % as operator and another {@code product}.
      *
      * @return a product parsed from the given input
      */
@@ -365,8 +368,7 @@ public class Parser {
      * in natural order (from left to right).
      */
     protected Node reOrder(Node left, Node right, BinaryNode.Op op) {
-        if (right instanceof BinaryNode) {
-            BinaryNode rightOp = (BinaryNode) right;
+        if (right instanceof BinaryNode rightOp) {
             if (!rightOp.isSealed() && rightOp.getOp().getPriority() == op.getPriority()) {
                 replaceLeft(rightOp, left, op);
                 return right;
@@ -376,8 +378,7 @@ public class Parser {
     }
 
     protected void replaceLeft(BinaryNode target, Node newLeft, BinaryNode.Op op) {
-        if (target.getLeft() instanceof BinaryNode) {
-            BinaryNode leftOp = (BinaryNode) target.getLeft();
+        if (target.getLeft() instanceof BinaryNode leftOp) {
             if (!leftOp.isSealed() && leftOp.getOp().getPriority() == op.getPriority()) {
                 replaceLeft(leftOp, newLeft, op);
                 return;
@@ -389,7 +390,7 @@ public class Parser {
     /**
      * Parser rule for parsing a power.
      * <p>
-     * A power is an <tt>atom</tt> which might be followed by ^ or ** as operator and another <tt>power</tt>.
+     * A power is an {@code atom} which might be followed by ^ or ** as operator and another {@code power}.
      *
      * @return a power parsed from the given input
      */
@@ -406,7 +407,7 @@ public class Parser {
     /**
      * Parser rule for parsing an atom.
      * <p>
-     * An atom is either a numeric constant, an <tt>expression</tt> in brackets, an <tt>expression</tt> surrounded by
+     * An atom is either a numeric constant, an {@code expression} in brackets, an {@code expression} surrounded by
      * | to signal the absolute function, an identifier to signal a variable reference or an identifier followed by a
      * bracket to signal a function call.
      *
@@ -476,28 +477,28 @@ public class Parser {
                 String quantifier = tokenizer.current().getContents().intern();
                 switch (quantifier) {
                     case "n":
-                        value /= 1000000000d;
+                        value /= 1000000000.0d;
                         tokenizer.consume();
                         break;
                     case "u":
-                        value /= 1000000d;
+                        value /= 1000000.0d;
                         tokenizer.consume();
                         break;
                     case "m":
-                        value /= 1000d;
+                        value /= 1000.0d;
                         tokenizer.consume();
                         break;
                     case "K":
                     case "k":
-                        value *= 1000d;
+                        value *= 1000.0d;
                         tokenizer.consume();
                         break;
                     case "M":
-                        value *= 1000000d;
+                        value *= 1000000.0d;
                         tokenizer.consume();
                         break;
                     case "G":
-                        value *= 1000000000d;
+                        value *= 1000000000.0d;
                         tokenizer.consume();
                         break;
                     default:

--- a/src/main/java/com/dfsek/paralithic/eval/parser/Scope.java
+++ b/src/main/java/com/dfsek/paralithic/eval/parser/Scope.java
@@ -69,7 +69,7 @@ public class Scope {
      * If a scope cannot resolve a constant, it tries to resolve it using its parent scope. This permits to
      * share a certain set of constants.
      *
-     * @param parent the parent scope to use. If <tt>null</tt>, the common root scope is used which defines a bunch of
+     * @param parent the parent scope to use. If {@code null}, the common root scope is used which defines a bunch of
      *               constants (e and pi).
      * @return the instance itself for fluent method calls
      */
@@ -86,7 +86,7 @@ public class Scope {
      * Searches or creates a constant in this scope.
      * <p>
      * Tries to find a constant with the given name in this scope.
-     * 
+     *
      * @param name the constant to create
      * @return a constant with the given name from the local scope
      */
@@ -129,10 +129,10 @@ public class Scope {
     /**
      * Searches for a {@link NamedConstant} with the given name.
      * <p>
-     * If the constant does not exist <tt>null</tt>  will be returned
+     * If the constant does not exist {@code null}  will be returned
      *
      * @param name the name of the constant to search
-     * @return the constant with the given name or <tt>null</tt> if no such constant was found
+     * @return the constant with the given name or {@code null} if no such constant was found
      */
     public NamedConstant find(String name) {
         if(context.containsKey(name)) {
@@ -150,7 +150,7 @@ public class Scope {
      * This does not remove the constant from a parent scope.
      *
      * @param name the name of the constant to remove
-     * @return the removed constant or <tt>null</tt> if no constant with the given name existed
+     * @return the removed constant or {@code null} if no constant with the given name existed
      */
     public NamedConstant remove(String name) {
         if(context.containsKey(name)) {

--- a/src/main/java/com/dfsek/paralithic/eval/tokenizer/Char.java
+++ b/src/main/java/com/dfsek/paralithic/eval/tokenizer/Char.java
@@ -49,7 +49,7 @@ public class Char implements Position {
     /**
      * Determines if the value is a digit (0..9)
      *
-     * @return <tt>true</tt> if the internal value is a digit, <tt>false</tt> otherwise
+     * @return {@code true} if the internal value is a digit, {@code false} otherwise
      */
     public boolean isDigit() {
         return Character.isDigit(value);
@@ -58,7 +58,7 @@ public class Char implements Position {
     /**
      * Determines if the value is a letter (a..z, A..Z)
      *
-     * @return <tt>true</tt> if the internal value is a letter, <tt>false</tt> otherwise
+     * @return {@code true} if the internal value is a letter, {@code false} otherwise
      */
     public boolean isLetter() {
         return Character.isLetter(value);
@@ -67,7 +67,7 @@ public class Char implements Position {
     /**
      * Determines if the value is a whitespace character like a blank, tab or line break
      *
-     * @return <tt>true</tt> if the internal value is a whitespace character, <tt>false</tt> otherwise
+     * @return {@code true} if the internal value is a whitespace character, {@code false} otherwise
      */
     public boolean isWhitespace() {
         return Character.isWhitespace(value) && !isEndOfInput();
@@ -76,8 +76,8 @@ public class Char implements Position {
     /**
      * Determines if this instance represents the end of input indicator
      *
-     * @return <tt>true</tt> if this instance represents the end of the underlying input,
-     * <tt>false</tt> otherwise
+     * @return {@code true} if this instance represents the end of the underlying input,
+     * {@code false} otherwise
      */
     public boolean isEndOfInput() {
         return value == '\0';
@@ -86,7 +86,7 @@ public class Char implements Position {
     /**
      * Determines if the value is a line break
      *
-     * @return <tt>true</tt> if the internal value is a line break, <tt>false</tt> otherwise
+     * @return {@code true} if the internal value is a line break, {@code false} otherwise
      */
     public boolean isNewLine() {
         return value == '\n';
@@ -105,7 +105,7 @@ public class Char implements Position {
      * Checks if the internal value is one of the given characters
      *
      * @param tests the characters to check against
-     * @return <tt>true</tt> if the value equals to one of the give characters, <tt>false</tt> otherwise
+     * @return {@code true} if the value equals to one of the give characters, {@code false} otherwise
      */
     public boolean is(char... tests) {
         for(char test : tests) {

--- a/src/main/java/com/dfsek/paralithic/eval/tokenizer/Lookahead.java
+++ b/src/main/java/com/dfsek/paralithic/eval/tokenizer/Lookahead.java
@@ -72,7 +72,7 @@ public abstract class Lookahead<T> {
      * Returns the next n-th item in the stream.
      * <p>
      * Calling this method with 0 as parameter, will return the current item. Calling it with 1 will return the
-     * same item as a call to <tt>next()</tt>.
+     * same item as a call to {@link Lookahead#next()}.
      * <p>
      * This method does not change the internal state. Therefore it can be called several times and will always
      * return the same result.
@@ -127,12 +127,12 @@ public abstract class Lookahead<T> {
     /**
      * Fetches the next item from the stream.
      *
-     * @return the next item in the stream or <tt>null</tt> to indicate that the end was reached
+     * @return the next item in the stream or {@code null} to indicate that the end was reached
      */
     protected abstract T fetch();
 
     /**
-     * Consumes (removes) <tt>numberOfItems</tt> at once.
+     * Consumes (removes) {@code numberOfItems} at once.
      * <p>
      * Removes the given number of items from the stream.
      *

--- a/src/main/java/com/dfsek/paralithic/eval/tokenizer/LookaheadReader.java
+++ b/src/main/java/com/dfsek/paralithic/eval/tokenizer/LookaheadReader.java
@@ -16,7 +16,7 @@ import java.io.Reader;
 /**
  * An efficient reader of character streams, reading character by character and supporting lookaheads.
  * <p>
- * Helps to read characters from a {@link Reader} one after another. Using <tt>next</tt>, upcoming characters can
+ * Helps to read characters from a {@link Reader} one after another. Using {@code next}, upcoming characters can
  * be inspected without consuming (removing) the current one.
  */
 public class LookaheadReader extends Lookahead<Char> {

--- a/src/main/java/com/dfsek/paralithic/eval/tokenizer/Token.java
+++ b/src/main/java/com/dfsek/paralithic/eval/tokenizer/Token.java
@@ -14,17 +14,17 @@ import java.util.stream.Stream;
 /**
  * Represents a token of text read from a {@link Tokenizer}.
  * <p>
- * A token consists of a position, a type and up to three string values. The first is the <tt>trigger</tt>. Along with
- * the type this uniquely identifies what kind of token we're looking at. For example the input <tt>"Hello"</tt>, the
- * id <tt>Hello</tt> and a special id like <tt>#Hello</tt> all have the same content (Hello). However, they will
- * have different types (<tt>STRING</tt>, <tt>ID</tt>, <tt>SPECIAL_ID</tt>). However, the two special ids
- * <tt>$Hello</tt> and <tt>#Hello</tt> will both have the same token type and content. Those will differ in their
- * <tt>trigger</tt> which will be <tt>#</tt> and <tt>$</tt> respectively.
+ * A token consists of a position, a type and up to three string values. The first is the {@code trigger}. Along with
+ * the type this uniquely identifies what kind of token we're looking at. For example the input {@code "Hello"}, the
+ * id {@code Hello} and a special id like {@code #Hello} all have the same content (Hello). However, they will
+ * have different types ({@code STRING}, {@code ID}, {@code SPECIAL_ID}). However, the two special ids
+ * {@code $Hello} and {@code #Hello} will both have the same token type and content. Those will differ in their
+ * {@code trigger} which will be {@code #} and {@code $} respectively.
  * <p>
- * As already shown, the <tt>content</tt> contains the effective content of the token which should be used for
- * further processing. Finally the <tt>source</tt> contains the complete text which was consumed while reading the
- * token. If we look at a string constant <tt>"Hello"</tt> the content will be <tt>Hello</tt> and the source will
- * be <tt>"Hello"</tt>.
+ * As already shown, the {@code content} contains the effective content of the token which should be used for
+ * further processing. Finally the {@code source} contains the complete text which was consumed while reading the
+ * token. If we look at a string constant {@code "Hello"} the content will be {@code Hello} and the source will
+ * be {@code "Hello"}.
  * <p>
  * The basic token types supported are:
  * <ul>
@@ -44,7 +44,7 @@ public class Token implements Position {
     protected int pos;
     private TokenType type;
     private String trigger = "";
-    private String internTrigger = null;
+    private String internTrigger;
     private String contents = "";
     private String source = "";
 
@@ -95,7 +95,7 @@ public class Token implements Position {
      * Adds the given Char to the trigger (and the source) but not to the content
      *
      * @param ch the character to add to the trigger and source
-     * @return <tt>this</tt> to support fluent method calls
+     * @return {@code this} to support fluent method calls
      */
     public Token addToTrigger(Char ch) {
         trigger += ch.getValue();
@@ -108,7 +108,7 @@ public class Token implements Position {
      * Adds the given Char to the source of this token, but neither to the trigger nor to the content.
      *
      * @param ch the character to add to the source
-     * @return <tt>this</tt> to support fluent method calls
+     * @return {@code this} to support fluent method calls
      */
     public Token addToSource(Char ch) {
         source += ch.getValue();
@@ -119,7 +119,7 @@ public class Token implements Position {
      * Adds the given Char to the content (and the source) but not to the trigger
      *
      * @param ch the character to add to the content and source
-     * @return <tt>this</tt> to support fluent method calls
+     * @return {@code this} to support fluent method calls
      */
     public Token addToContent(Char ch) {
         return addToContent(ch.getValue());
@@ -129,7 +129,7 @@ public class Token implements Position {
      * Adds the given character to the content (and the source) but not to the trigger
      *
      * @param ch the character to add to the content and source
-     * @return <tt>this</tt> to support fluent method calls
+     * @return {@code this} to support fluent method calls
      */
     public Token addToContent(char ch) {
         contents += ch;
@@ -141,7 +141,7 @@ public class Token implements Position {
      * Adds a character to the content without adding it to the source.
      *
      * @param ch the character to add to the content
-     * @return <tt>this</tt> to support fluent method calls
+     * @return {@code this} to support fluent method calls
      */
     public Token silentAddToContent(char ch) {
         contents += ch;
@@ -172,7 +172,7 @@ public class Token implements Position {
     /**
      * Determines if this is an end of input token
      *
-     * @return <tt>true</tt> if this is an end of input token (with EOI as type), <tt>false</tt> otherwise
+     * @return {@code true} if this is an end of input token (with EOI as type), {@code false} otherwise
      */
     public boolean isEnd() {
         return type == TokenType.EOI;
@@ -181,7 +181,7 @@ public class Token implements Position {
     /**
      * Opposite of {@link #isEnd()}.
      *
-     * @return <tt>false</tt> if this is an end of input token (with EOI as type), <tt>true</tt> otherwise
+     * @return {@code false} if this is an end of input token (with EOI as type), {@code true} otherwise
      */
     public boolean isNotEnd() {
         return type != TokenType.EOI;
@@ -191,7 +191,7 @@ public class Token implements Position {
      * Determines if this token was triggered by one of the given triggers.
      *
      * @param triggers a list of possible triggers to compare to
-     * @return <tt>true</tt> if this token was triggered by one of the given triggers, <tt>false</tt> otherwise
+     * @return {@code true} if this token was triggered by one of the given triggers, {@code false} otherwise
      */
     public boolean wasTriggeredBy(String... triggers) {
         return Stream.of(triggers).filter(Objects::nonNull).anyMatch(trigger -> Objects.equals(trigger, getTrigger()));
@@ -225,14 +225,14 @@ public class Token implements Position {
      * Determines if the given content matches the content of this token.
      *
      * @param content the content to check for
-     * @return <tt>true</tt> if the content of this token equals the given content (ignoring case),
-     * <tt>false</tt> otherwise
+     * @return {@code true} if the content of this token equals the given content (ignoring case),
+     * {@code false} otherwise
      */
     public boolean hasContent(String content) {
         if(content == null) {
             throw new IllegalArgumentException("content must not be null");
         }
-        return content.equalsIgnoreCase(getContents());
+        return content.equalsIgnoreCase(contents);
     }
 
     /**
@@ -247,10 +247,10 @@ public class Token implements Position {
     /**
      * Determines if this token is a symbol.
      * <p>
-     * If a list of <tt>symbols</tt> is given, this method checks that the trigger matches one of them.
+     * If a list of {@code symbols} is given, this method checks that the trigger matches one of them.
      *
      * @param symbols the symbols to check for. If the list es empty, only the token type is checked.
-     * @return <tt>true</tt> if this token is a symbol and matches one of the given <tt>symbols</tt> if the list
+     * @return {@code true} if this token is a symbol and matches one of the given {@code symbols} if the list
      * is not empty.
      */
     public boolean isSymbol(String... symbols) {
@@ -269,7 +269,7 @@ public class Token implements Position {
      * Determines if the token has the given type
      *
      * @param type the expected type
-     * @return <tt>true</tt> if this token has the given type, <tt>false</tt> otherwise
+     * @return {@code true} if this token has the given type, {@code false} otherwise
      */
     public boolean is(TokenType type) {
         return this.type == type;
@@ -280,7 +280,7 @@ public class Token implements Position {
      *
      * @param type    the expected type
      * @param trigger the expected trigger
-     * @return <tt>true</tt> if this token matches the given type and trigger, <tt>false</tt> otherwise
+     * @return {@code true} if this token matches the given type and trigger, {@code false} otherwise
      */
     public boolean matches(TokenType type, String trigger) {
         if(!is(type)) {
@@ -296,10 +296,10 @@ public class Token implements Position {
     /**
      * Determines if this token is a keyword.
      * <p>
-     * If a list of <tt>symbols</tt> is given, this method checks that the trigger matches one of them.
+     * If a list of {@code symbols} is given, this method checks that the trigger matches one of them.
      *
      * @param keywords the keywords to check for. If the list es empty, only the token type is checked.
-     * @return <tt>true</tt> if this token is a keyword and matches one of the given <tt>keywords</tt> if the list
+     * @return {@code true} if this token is a keyword and matches one of the given {@code keywords} if the list
      * is not empty.
      */
     public boolean isKeyword(String... keywords) {
@@ -317,10 +317,10 @@ public class Token implements Position {
     /**
      * Determines if this token is an identifier.
      * <p>
-     * If a list of <tt>values</tt> is given, this method checks that the content matches one of them.
+     * If a list of {@code values} is given, this method checks that the content matches one of them.
      *
      * @param values the values to check for. If the list es empty, only the token type is checked.
-     * @return <tt>true</tt> if this token is an identifier and matches one of the given <tt>values</tt> if the list
+     * @return {@code true} if this token is an identifier and matches one of the given {@code values} if the list
      * is not empty.
      */
     public boolean isIdentifier(String... values) {
@@ -338,10 +338,10 @@ public class Token implements Position {
     /**
      * Determines if this token is a special identifier.
      * <p>
-     * If a list of <tt>triggers</tt> is given, this method checks that the trigger matches one of them.
+     * If a list of {@code triggers} is given, this method checks that the trigger matches one of them.
      *
      * @param triggers the triggers to check for. If the list es empty, only the token type is checked.
-     * @return <tt>true</tt> if this token is a special identifier and matches one of the given <tt>triggers</tt>
+     * @return {@code true} if this token is a special identifier and matches one of the given {@code triggers}
      * if the list is not empty.
      */
     public boolean isSpecialIdentifier(String... triggers) {
@@ -359,12 +359,12 @@ public class Token implements Position {
     /**
      * Determines if this token is a special identifier with the given trigger.
      * <p>
-     * If a list of <tt>contents</tt> is given, this method checks that the content matches one of them.
+     * If a list of {@code contents} is given, this method checks that the content matches one of them.
      *
      * @param trigger  the trigger of the special id
      * @param contents the content to check for. If the list es empty, only the token type and the trigger is checked.
-     * @return <tt>true</tt> if this token is a special identifier with the given trigger.
-     * If <tt>contents</tt> is not empty, the content must also match one of the elements.
+     * @return {@code true} if this token is a special identifier with the given trigger.
+     * If {@code contents} is not empty, the content must also match one of the elements.
      */
     public boolean isSpecialIdentifierWithContent(String trigger, String... contents) {
         if(!matches(TokenType.SPECIAL_ID, trigger)) {
@@ -374,7 +374,7 @@ public class Token implements Position {
             return true;
         }
         for(String content : contents) {
-            if(content != null && content.equals(getContents())) {
+            if(content != null && content.equals(this.contents)) {
                 return true;
             }
         }
@@ -384,7 +384,7 @@ public class Token implements Position {
     /**
      * Determines if this token is an integer or decimal number.
      *
-     * @return <tt>true</tt> if this token is an integer or decimal number, <tt>false</tt> otherwise
+     * @return {@code true} if this token is an integer or decimal number, {@code false} otherwise
      */
     public boolean isNumber() {
         return isInteger() || isDecimal() || isScientificDecimal();
@@ -393,7 +393,7 @@ public class Token implements Position {
     /**
      * Determines if this token is an integer number.
      *
-     * @return <tt>true</tt> if this token is an integer number, <tt>false</tt> otherwise
+     * @return {@code true} if this token is an integer number, {@code false} otherwise
      */
     public boolean isInteger() {
         return is(TokenType.INTEGER);
@@ -402,7 +402,7 @@ public class Token implements Position {
     /**
      * Determines if this token is a decimal number.
      *
-     * @return <tt>true</tt> if this token is a decimal number, <tt>false</tt> otherwise
+     * @return {@code true} if this token is a decimal number, {@code false} otherwise
      */
     public boolean isDecimal() {
         return is(TokenType.DECIMAL);
@@ -411,7 +411,7 @@ public class Token implements Position {
     /**
      * Determines if this token is a scientific decimal number (e.g. 3.2e5).
      *
-     * @return <tt>true</tt> if this token is a scientific decimal number, <tt>false</tt> otherwise
+     * @return {@code true} if this token is a scientific decimal number, {@code false} otherwise
      */
     public boolean isScientificDecimal() {
         return is(TokenType.SCIENTIFIC_DECIMAL);
@@ -420,7 +420,7 @@ public class Token implements Position {
     /**
      * Determines if this token is a string constant
      *
-     * @return <tt>true</tt> if this token is a string constant, <tt>false</tt> otherwise
+     * @return {@code true} if this token is a string constant, {@code false} otherwise
      */
     public boolean isString() {
         return is(TokenType.STRING);
@@ -428,7 +428,7 @@ public class Token implements Position {
 
     @Override
     public String toString() {
-        return getType().toString() + ":" + getSource() + " (" + line + ":" + pos + ")";
+        return type.toString() + ":" + source + " (" + line + ":" + pos + ")";
     }
 
     /**

--- a/src/main/java/com/dfsek/paralithic/eval/tokenizer/Tokenizer.java
+++ b/src/main/java/com/dfsek/paralithic/eval/tokenizer/Tokenizer.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * <li>If the current character is an opening or closing bracket, a SYMBOL for that single character is returned</li>
  * <li>If the current character is one of the special id starters, all valid ID characters
  * ({@link #isIdentifierChar(Char)} are consumed and returned as SPECIAL_ID</li>
- * <li>All other characters, especially all operators, will be read and returned as one SYMBOL. Therefore <tt>#++*</tt>
+ * <li>All other characters, especially all operators, will be read and returned as one SYMBOL. Therefore {@code #++*}
  * will be returned as a single symbol.</li>
  * </ul>
  */
@@ -212,9 +212,9 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Determines if the underlying input is looking at the start of a special id.
      * <p>
-     * By default this is one of the given <tt>specialIdStarters</tt>.
+     * By default this is one of the given {@code specialIdStarters}.
      *
-     * @return <tt>true</tt> if the current input is the start of a special id, <tt>false</tt> otherwise
+     * @return {@code true} if the current input is the start of a special id, {@code false} otherwise
      */
     protected boolean isAtStartOfSpecialId() {
         return specialIdStarters.contains(input.current().getValue());
@@ -225,7 +225,7 @@ public class Tokenizer extends Lookahead<Token> {
      * <p>
      * By default this is either indicated by a digit or by '-' followed by a digit or a '.' followed by a digit.
      *
-     * @return <tt>true</tt> if the current input is the start of a numeric constant, <tt>false</tt> otherwise
+     * @return {@code true} if the current input is the start of a numeric constant, {@code false} otherwise
      */
     protected boolean isAtStartOfNumber() {
         return input.current().isDigit()
@@ -237,11 +237,11 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Determines if the underlying input is looking at a bracket.
      * <p>
-     * By default all supplied <tt>brackets</tt> are checked. If <tt>treatSinglePipeAsBracket</tt> is true, a
+     * By default all supplied {@code brackets} are checked. If {@code treatSinglePipeAsBracket} is true, a
      * single '|' is also treated as bracket.
      *
      * @param inSymbol determines if we're already parsing a symbol or just trying to decide what the next token is
-     * @return <tt>true</tt> if the current input is an opening or closing bracket
+     * @return {@code true} if the current input is an opening or closing bracket
      */
     protected boolean isAtBracket(boolean inSymbol) {
         return input.current().is(BRACKETS) || !inSymbol
@@ -255,7 +255,7 @@ public class Tokenizer extends Lookahead<Token> {
      *
      * @param string  the string to check
      * @param consume determines if the matched string should be consumed immediately
-     * @return <tt>true</tt> if the next characters of the input match the given string, <tt>false</tt>
+     * @return {@code true} if the next characters of the input match the given string, {@code false}
      * otherwise
      */
     protected boolean canConsumeThisString(String string, boolean consume) {
@@ -277,10 +277,10 @@ public class Tokenizer extends Lookahead<Token> {
      * Checks if the underlying input is looking at a start of line comment.
      * <p>
      * If a line comment is detected, any characters indicating this are consumed by this method if
-     * <tt>consume</tt> is <tt>true</tt>.
+     * {@code consume} is {@code true}.
      *
      * @param consume determines if the matched comment start should be consumed immediately
-     * @return <tt>true</tt> if the next character(s) of the input start a line comment, <tt>false</tt> otherwise
+     * @return {@code true} if the next character(s) of the input start a line comment, {@code false} otherwise
      */
     protected boolean isAtStartOfLineComment(boolean consume) {
         if(lineComment != null) {
@@ -302,11 +302,11 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Checks if the underlying input is looking at a start of block comment
      * <p>
-     * If a block comment is detected, any characters indicating this are consumed by this method if <tt>consume</tt>
-     * is <tt>true</tt> .
+     * If a block comment is detected, any characters indicating this are consumed by this method if {@code consume}
+     * is {@code true} .
      *
      * @param consume determines if the block comment starter is to be consumed if found or not
-     * @return <tt>true</tt> if the next character(s) of the input start a block comment, <tt>false</tt> otherwise
+     * @return {@code true} if the next character(s) of the input start a block comment, {@code false} otherwise
      */
     protected boolean isAtStartOfBlockComment(boolean consume) {
         return canConsumeThisString(blockCommentStart, consume);
@@ -317,7 +317,7 @@ public class Tokenizer extends Lookahead<Token> {
      * <p>
      * If an end of block comment is detected, any characters indicating this are consumed by this method
      *
-     * @return <tt>true</tt> if the next character(s) of the input end a block comment, <tt>false</tt> otherwise
+     * @return {@code true} if the next character(s) of the input end a block comment, {@code false} otherwise
      */
     protected boolean isAtEndOfBlockComment() {
         return canConsumeThisString(blockCommentEnd, true);
@@ -375,7 +375,7 @@ public class Tokenizer extends Lookahead<Token> {
      * @param separator   the delimiter of this string constant
      * @param escapeChar  the escape character used
      * @param stringToken the resulting string constant
-     * @return <tt>true</tt> if an escape was possible, <tt>false</tt> otherwise
+     * @return {@code true} if an escape was possible, {@code false} otherwise
      */
     protected boolean handleStringEscape(char separator, char escapeChar, Token stringToken) {
         if(input.current().is(separator)) {
@@ -404,7 +404,7 @@ public class Tokenizer extends Lookahead<Token> {
      * <p>
      * By default, only letters can start identifiers
      *
-     * @return <tt>true</tt> if the underlying input is looking at a valid identifier starter, <tt>false</tt> otherwise
+     * @return {@code true} if the underlying input is looking at a valid identifier starter, {@code false} otherwise
      */
     protected boolean isAtStartOfIdentifier() {
         return input.current().isLetter();
@@ -461,7 +461,7 @@ public class Tokenizer extends Lookahead<Token> {
      * By default, letters, digits and '_' are valid identifier parts.
      *
      * @param current the character to check
-     * @return <tt>true</tt> if the given Char is a valid identifier part, <tt>false</tt> otherwise
+     * @return {@code true} if the given Char is a valid identifier part, {@code false} otherwise
      */
     protected boolean isIdentifierChar(Char current) {
         return current.isDigit() || current.isLetter() || current.is('_');
@@ -507,7 +507,7 @@ public class Tokenizer extends Lookahead<Token> {
      * By default these are all non-control characters, which don't match any other class (letter, digit, whitepsace)
      *
      * @param ch the character to check
-     * @return <tt>true</tt> if the given character is a valid symbol character, <tt>false</tt> otherwise
+     * @return {@code true} if the given character is a valid symbol character, {@code false} otherwise
      */
     protected boolean isSymbolCharacter(Char ch) {
         if(ch.isEndOfInput() || ch.isDigit() || ch.isLetter() || ch.isWhitespace()) {
@@ -580,7 +580,7 @@ public class Tokenizer extends Lookahead<Token> {
      * <p>
      * By default, keywords aren't case sensitive. Therefore True and true are the same keyword.
      *
-     * @return <tt>true</tt> if keywords are case sensitive, <tt>false</tt> otherwise
+     * @return {@code true} if keywords are case sensitive, {@code false} otherwise
      */
     public boolean isKeywordsCaseSensitive() {
         return keywordsCaseSensitive;
@@ -592,7 +592,7 @@ public class Tokenizer extends Lookahead<Token> {
      * This must be setup before any call to {@link #addKeyword(String)} as this will determine internal data
      * structures
      *
-     * @param keywordsCaseSensitive <tt>true</tt> if keywords should be treated as case sensitive, <tt>false</tt>
+     * @param keywordsCaseSensitive {@code true} if keywords should be treated as case sensitive, {@code false}
      *                              otherwise (default)
      */
     public void setKeywordsCaseSensitive(boolean keywordsCaseSensitive) {
@@ -790,7 +790,7 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Boilerplate method for {@code current().isNotEnd()}
      *
-     * @return <tt>true</tt> if the current token is not an "end of input" token, <tt>false</tt> otherwise.
+     * @return {@code true} if the current token is not an "end of input" token, {@code false} otherwise.
      */
     public boolean more() {
         return current().isNotEnd();
@@ -799,7 +799,7 @@ public class Tokenizer extends Lookahead<Token> {
     /**
      * Boilerplate method for {@code current().isEnd()}
      *
-     * @return <tt>true</tt> if the current token is an "end of input" token, <tt>false</tt> otherwise.
+     * @return {@code true} if the current token is an "end of input" token, {@code false} otherwise.
      */
     public boolean atEnd() {
         return current().isEnd();
@@ -822,7 +822,7 @@ public class Tokenizer extends Lookahead<Token> {
     }
 
     /**
-     * Consumes the current token, expecting it to be as <tt>SYMBOL</tt> with the given content
+     * Consumes the current token, expecting it to be as {@code SYMBOL} with the given content
      *
      * @param symbol the expected trigger of the current token
      */
@@ -852,7 +852,7 @@ public class Tokenizer extends Lookahead<Token> {
     }
 
     /**
-     * Consumes the current token, expecting it to be as <tt>KEYWORD</tt> with the given content
+     * Consumes the current token, expecting it to be as {@code KEYWORD} with the given content
      *
      * @param keyword the expected content of the current token
      */

--- a/src/test/java/EvalTest.java
+++ b/src/test/java/EvalTest.java
@@ -14,6 +14,7 @@ import com.dfsek.paralithic.functions.dynamic.Context;
 import com.dfsek.paralithic.functions.dynamic.DynamicFunction;
 import com.dfsek.paralithic.node.Statefulness;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,104 +27,106 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 2013/09
  */
 public class EvalTest {
-    private static final Parser p;
     private static final double EPSILON = 1.0E-5;
+    private Parser parser;
 
-    static {
-        p = new Parser();
+    @BeforeEach
+    public void setup() {
+        parser = new Parser();
     }
+
     @Test
     public void simple() throws ParseException {
-        assertEquals(-109d, p.eval("1 - (10 - -100)"), EPSILON);
-        assertEquals(10, p.eval("1 + 2 + 3 + 4"), EPSILON);
-        assertEquals(0.01d, p.eval("1 / 10 * 10 / 100"), EPSILON);
-        assertEquals(-89d, p.eval("1 + 10 - 100"), EPSILON);
-        assertEquals(91d, p.eval("1 - 10 - -100"), EPSILON);
-        assertEquals(91d, p.eval("1 - 10  + 100"), EPSILON);
-        assertEquals(-109d, p.eval("1 - (10 + 100)"), EPSILON);
-        assertEquals(-89d, p.eval("1 + (10 - 100)"), EPSILON);
-        assertEquals(100d, p.eval("1 / 1 * 100"), EPSILON);
-        assertEquals(0.01d, p.eval("1 / (1 * 100)"), EPSILON);
-        assertEquals(0.01d, p.eval("1 * 1 / 100"), EPSILON);
-        assertEquals(7d, p.eval("3+4"), EPSILON);
-        assertEquals(7d, p.eval("3      +    4"), EPSILON);
-        assertEquals(-1d, p.eval("3+ -4"), EPSILON);
-        assertEquals(-1d, p.eval("3+(-4)"), EPSILON);
+        assertEquals(-109d, parser.eval("1 - (10 - -100)"), EPSILON);
+        assertEquals(10, parser.eval("1 + 2 + 3 + 4"), EPSILON);
+        assertEquals(0.01d, parser.eval("1 / 10 * 10 / 100"), EPSILON);
+        assertEquals(-89d, parser.eval("1 + 10 - 100"), EPSILON);
+        assertEquals(91d, parser.eval("1 - 10 - -100"), EPSILON);
+        assertEquals(91d, parser.eval("1 - 10  + 100"), EPSILON);
+        assertEquals(-109d, parser.eval("1 - (10 + 100)"), EPSILON);
+        assertEquals(-89d, parser.eval("1 + (10 - 100)"), EPSILON);
+        assertEquals(100d, parser.eval("1 / 1 * 100"), EPSILON);
+        assertEquals(0.01d, parser.eval("1 / (1 * 100)"), EPSILON);
+        assertEquals(0.01d, parser.eval("1 * 1 / 100"), EPSILON);
+        assertEquals(7d, parser.eval("3+4"), EPSILON);
+        assertEquals(7d, parser.eval("3      +    4"), EPSILON);
+        assertEquals(-1d, parser.eval("3+ -4"), EPSILON);
+        assertEquals(-1d, parser.eval("3+(-4)"), EPSILON);
     }
 
     @Test
     public void number() throws ParseException {
-        assertEquals(4003.333333d, p.eval("3.333_333+4_000"), EPSILON);
-        assertEquals(0.03, p.eval("3e-2"), EPSILON);
-        assertEquals(300d, p.eval("3e2"), EPSILON);
-        assertEquals(300d, p.eval("3e+2"), EPSILON);
-        assertEquals(320d, p.eval("3.2e2"), EPSILON);
-        assertEquals(0.032, p.eval("3.2e-2"), EPSILON);
-        assertEquals(0.03, p.eval("3E-2"), EPSILON);
-        assertEquals(300d, p.eval("3E2"), EPSILON);
-        assertEquals(300d, p.eval("3E+2"), EPSILON);
-        assertEquals(320d, p.eval("3.2E2"), EPSILON);
-        assertEquals(0.032, p.eval("3.2E-2"), EPSILON);
+        assertEquals(4003.333333d, parser.eval("3.333_333+4_000"), EPSILON);
+        assertEquals(0.03, parser.eval("3e-2"), EPSILON);
+        assertEquals(300d, parser.eval("3e2"), EPSILON);
+        assertEquals(300d, parser.eval("3e+2"), EPSILON);
+        assertEquals(320d, parser.eval("3.2e2"), EPSILON);
+        assertEquals(0.032, parser.eval("3.2e-2"), EPSILON);
+        assertEquals(0.03, parser.eval("3E-2"), EPSILON);
+        assertEquals(300d, parser.eval("3E2"), EPSILON);
+        assertEquals(300d, parser.eval("3E+2"), EPSILON);
+        assertEquals(320d, parser.eval("3.2E2"), EPSILON);
+        assertEquals(0.032, parser.eval("3.2E-2"), EPSILON);
     }
 
     @Test
     public void precedence() throws ParseException {
         // term vs. product
-        assertEquals(19d, p.eval("3+4*4"), EPSILON);
+        assertEquals(19d, parser.eval("3+4*4"), EPSILON);
         // product vs. power
-        assertEquals(20.25d, p.eval("3^4/4"), EPSILON);
+        assertEquals(20.25d, parser.eval("3^4/4"), EPSILON);
         // relation vs. product
-        assertEquals(1d, p.eval("3 < 4*4"), EPSILON);
-        assertEquals(0d, p.eval("3 > 4*4"), EPSILON);
+        assertEquals(1d, parser.eval("3 < 4*4"), EPSILON);
+        assertEquals(0d, parser.eval("3 > 4*4"), EPSILON);
         // brackets
-        assertEquals(28d, p.eval("(3 + 4) * 4"), EPSILON);
-        assertEquals(304d, p.eval("3e2 + 4"), EPSILON);
-        assertEquals(1200d, p.eval("3e2 * 4"), EPSILON);
+        assertEquals(28d, parser.eval("(3 + 4) * 4"), EPSILON);
+        assertEquals(304d, parser.eval("3e2 + 4"), EPSILON);
+        assertEquals(1200d, parser.eval("3e2 * 4"), EPSILON);
     }
 
     @Test
     public void signed() throws ParseException {
-        assertEquals(-2.02, p.eval("-2.02"), EPSILON);
-        assertEquals(2.02, p.eval("+2.02"), EPSILON);
-        assertEquals(1.01, p.eval("+2.02 + -1.01"), EPSILON);
-        assertEquals(-4.03, p.eval("-2.02 - +2.01"), EPSILON);
-        assertEquals(3.03, p.eval("+2.02 + +1.01"), EPSILON);
+        assertEquals(-2.02, parser.eval("-2.02"), EPSILON);
+        assertEquals(2.02, parser.eval("+2.02"), EPSILON);
+        assertEquals(1.01, parser.eval("+2.02 + -1.01"), EPSILON);
+        assertEquals(-4.03, parser.eval("-2.02 - +2.01"), EPSILON);
+        assertEquals(3.03, parser.eval("+2.02 + +1.01"), EPSILON);
     }
 
     @Test
     public void blockComment() throws ParseException {
-        assertEquals(29, p.eval("27+ /*xxx*/ 2"), EPSILON);
-        assertEquals(29, p.eval("27+/*xxx*/ 2"), EPSILON);
-        assertEquals(29, p.eval("27/*xxx*/+2"), EPSILON);
+        assertEquals(29, parser.eval("27+ /*xxx*/ 2"), EPSILON);
+        assertEquals(29, parser.eval("27+/*xxx*/ 2"), EPSILON);
+        assertEquals(29, parser.eval("27/*xxx*/+2"), EPSILON);
     }
 
     @Test
     public void startingWithDecimalPoint() throws ParseException {
-        assertEquals(.2, p.eval(".2"), EPSILON);
-        assertEquals(.2, p.eval("+.2"), EPSILON);
-        assertEquals(.4, p.eval(".2+.2"), EPSILON);
-        assertEquals(.4, p.eval(".6+-.2"), EPSILON);
+        assertEquals(.2, parser.eval(".2"), EPSILON);
+        assertEquals(.2, parser.eval("+.2"), EPSILON);
+        assertEquals(.4, parser.eval(".2+.2"), EPSILON);
+        assertEquals(.4, parser.eval(".6+-.2"), EPSILON);
     }
 
     @Test
     public void signedParentheses() throws ParseException {
-        assertEquals(0.2, p.eval("-(-0.2)"), EPSILON);
-        assertEquals(1.2, p.eval("1-(-0.2)"), EPSILON);
-        assertEquals(0.8, p.eval("1+(-0.2)"), EPSILON);
-        assertEquals(2.2, p.eval("+(2.2)"), EPSILON);
+        assertEquals(0.2, parser.eval("-(-0.2)"), EPSILON);
+        assertEquals(1.2, parser.eval("1-(-0.2)"), EPSILON);
+        assertEquals(0.8, parser.eval("1+(-0.2)"), EPSILON);
+        assertEquals(2.2, parser.eval("+(2.2)"), EPSILON);
     }
 
     @Test
     public void trailingDecimalPoint() throws ParseException {
-        assertEquals(2., p.eval("2."), EPSILON);
+        assertEquals(2., parser.eval("2."), EPSILON);
     }
 
     @Test
     public void signedValueAfterOperand() throws ParseException {
-        assertEquals(-1.2, p.eval("1+-2.2"), EPSILON);
-        assertEquals(3.2, p.eval("1++2.2"), EPSILON);
-        assertEquals(6 * -1.1, p.eval("6*-1.1"), EPSILON);
-        assertEquals(6 * 1.1, p.eval("6*+1.1"), EPSILON);
+        assertEquals(-1.2, parser.eval("1+-2.2"), EPSILON);
+        assertEquals(3.2, parser.eval("1++2.2"), EPSILON);
+        assertEquals(6 * -1.1, parser.eval("6*-1.1"), EPSILON);
+        assertEquals(6 * 1.1, parser.eval("6*+1.1"), EPSILON);
     }
 
     @Test
@@ -132,7 +135,7 @@ public class EvalTest {
 
         scope.create("a", 2);
         scope.create("b", 3);
-        double result = p.eval("3*a + 4 * b", scope);
+        double result = parser.eval("3*a + 4 * b", scope);
 
         assertEquals(18d, result, EPSILON);
         assertEquals(18d, result, EPSILON);
@@ -140,28 +143,28 @@ public class EvalTest {
 
     @Test
     public void functions() throws ParseException {
-        assertEquals(0d, p.eval("1 + sin(-pi) + cos(pi)"), EPSILON);
-        assertEquals(4.72038341576d, p.eval("tan(sqrt(euler ^ (pi * 3)))"), EPSILON);
-        assertEquals(3d, p.eval("| 3 - 6 |"), EPSILON);
-        assertEquals(3d, p.eval("if(3 > 2 && 2 < 3, 2+1, 1+1)"), EPSILON);
-        assertEquals(2d, p.eval("if(3 < 2 || 2 > 3, 2+1, 1+1)"), EPSILON);
-        assertEquals(3d, p.eval("if(1, 2+1, 1+1)"), EPSILON);
-        assertEquals(2d, p.eval("if(0, 2+1, 1+1)"), EPSILON);
-        assertEquals(2d, p.eval("min(3,2)"), EPSILON);
-        assertEquals(2d, p.eval("abs(2)"), EPSILON);
-        assertEquals(2d, p.eval("abs(-2)"), EPSILON);
-        assertEquals(-3d, p.eval("floor(-2.2)"), EPSILON);
-        assertEquals(-2d, p.eval("ceil(-2.2)"), EPSILON);
+        assertEquals(0d, parser.eval("1 + sin(-pi) + cos(pi)"), EPSILON);
+        assertEquals(4.72038341576d, parser.eval("tan(sqrt(euler ^ (pi * 3)))"), EPSILON);
+        assertEquals(3d, parser.eval("| 3 - 6 |"), EPSILON);
+        assertEquals(3d, parser.eval("if(3 > 2 && 2 < 3, 2+1, 1+1)"), EPSILON);
+        assertEquals(2d, parser.eval("if(3 < 2 || 2 > 3, 2+1, 1+1)"), EPSILON);
+        assertEquals(3d, parser.eval("if(1, 2+1, 1+1)"), EPSILON);
+        assertEquals(2d, parser.eval("if(0, 2+1, 1+1)"), EPSILON);
+        assertEquals(2d, parser.eval("min(3,2)"), EPSILON);
+        assertEquals(2d, parser.eval("abs(2)"), EPSILON);
+        assertEquals(2d, parser.eval("abs(-2)"), EPSILON);
+        assertEquals(-3d, parser.eval("floor(-2.2)"), EPSILON);
+        assertEquals(-2d, parser.eval("ceil(-2.2)"), EPSILON);
 
         Scope scope = new Scope();
         scope.addInvocationVariable("x");
-        assertEquals(1d, p.eval("if(x, 0, 1)", scope, 0), EPSILON);
-        assertEquals(0d, p.eval("if(x, 0, 1)", scope, 10), EPSILON);
+        assertEquals(1d, parser.eval("if(x, 0, 1)", scope, 0), EPSILON);
+        assertEquals(0d, parser.eval("if(x, 0, 1)", scope, 10), EPSILON);
 
 
         // Test a var arg method...
-        p.registerFunction("avg", avgFun);
-        assertEquals(3.25d, p.eval("avg(3,2,1,7)"), EPSILON);
+        parser.registerFunction("avg", avgFun);
+        assertEquals(3.25d, parser.eval("avg(3,2,1,7)"), EPSILON);
     }
 
     DynamicFunction avgFun = new DynamicFunction() {
@@ -212,8 +215,8 @@ public class EvalTest {
         root.create("d", 9);
         subScope1.create("d", 7);
 
-        double expr1 = p.eval("a + b + c + d", subScope1);
-        double expr2 = p.eval("a + b + c + d", subScope2);
+        double expr1 = parser.eval("a + b + c + d", subScope1);
+        double expr2 = parser.eval("a + b + c + d", subScope2);
         assertEquals(15d, expr1, EPSILON);
         assertEquals(17d, expr2, EPSILON);
     }
@@ -222,7 +225,7 @@ public class EvalTest {
     public void errors() {
         // We expect the parser to continue after an recoverable error!
         try {
-            p.eval("test(1 2)+sin(1,2)*34-34.45.45+");
+            parser.eval("test(1 2)+sin(1,2)*34-34.45.45+");
             fail();
         } catch (ParseException e) {
             assertEquals(5, e.getErrors().size());
@@ -230,7 +233,7 @@ public class EvalTest {
 
         // We expect the parser to report an invalid quantifier.
         try {
-            p.eval("1x");
+            parser.eval("1x");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -238,7 +241,7 @@ public class EvalTest {
 
         // We expect the parser to report an unfinished expression
         try {
-            p.eval("1(");
+            parser.eval("1(");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -246,7 +249,7 @@ public class EvalTest {
 
         // We expect the parser to report an unexpected separator.
         try {
-            p.eval("3ee3");
+            parser.eval("3ee3");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -254,7 +257,7 @@ public class EvalTest {
 
         // We expect the parser to report an unexpected separator.
         try {
-            p.eval("3e3.3");
+            parser.eval("3e3.3");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -262,7 +265,7 @@ public class EvalTest {
 
         // We expect the parser to report an unexpected token.
         try {
-            p.eval("3e");
+            parser.eval("3e");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -272,19 +275,19 @@ public class EvalTest {
     @Test
     public void relationalOperators() throws ParseException {
         // Test for Issue with >= and <= operators (#4)
-        assertEquals(1d, p.eval("5 <= 5"), EPSILON);
-        assertEquals(1d, p.eval("5 >= 5"), EPSILON);
-        assertEquals(0d, p.eval("5 < 5"), EPSILON);
-        assertEquals(0d, p.eval("5 > 5"), EPSILON);
+        assertEquals(1d, parser.eval("5 <= 5"), EPSILON);
+        assertEquals(1d, parser.eval("5 >= 5"), EPSILON);
+        assertEquals(0d, parser.eval("5 < 5"), EPSILON);
+        assertEquals(0d, parser.eval("5 > 5"), EPSILON);
     }
 
     @Test
     public void quantifiers() throws ParseException {
-        assertEquals(1000d, p.eval("1K"), EPSILON);
-        assertEquals(1000d, p.eval("1M * 1m"), EPSILON);
-        assertEquals(1d, p.eval("1n * 1G"), EPSILON);
-        assertEquals(1d, p.eval("(1M / 1k) * 1m"), EPSILON);
-        assertEquals(1d, p.eval("1u * 10 k * 1000  m * 0.1 k"), EPSILON);
+        assertEquals(1000d, parser.eval("1K"), EPSILON);
+        assertEquals(1000d, parser.eval("1M * 1m"), EPSILON);
+        assertEquals(1d, parser.eval("1n * 1G"), EPSILON);
+        assertEquals(1d, parser.eval("(1M / 1k) * 1m"), EPSILON);
+        assertEquals(1d, parser.eval("1u * 10 k * 1000  m * 0.1 k"), EPSILON);
     }
 
     @Test
@@ -293,13 +296,13 @@ public class EvalTest {
         try {
             s.create("a", 0);
             s.create("b", 0);
-            p.eval("a*b+c", s);
+            parser.eval("a*b+c", s);
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
 
         s.create("c", 0);
-        p.eval("a*b+c", s);
+        parser.eval("a*b+c", s);
     }
 
     @Test

--- a/src/test/java/EvalTest.java
+++ b/src/test/java/EvalTest.java
@@ -14,9 +14,9 @@ import com.dfsek.paralithic.functions.dynamic.Context;
 import com.dfsek.paralithic.functions.dynamic.DynamicFunction;
 import com.dfsek.paralithic.node.Statefulness;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**

--- a/src/test/java/EvalTest.java
+++ b/src/test/java/EvalTest.java
@@ -36,56 +36,56 @@ public class EvalTest {
     }
 
     @Test
-    public void simple() throws ParseException {
-        assertEquals(-109d, parser.eval("1 - (10 - -100)"), EPSILON);
+    public void testSimpleExpressions() throws ParseException {
+        assertEquals(-109, parser.eval("1 - (10 - -100)"), EPSILON);
         assertEquals(10, parser.eval("1 + 2 + 3 + 4"), EPSILON);
-        assertEquals(0.01d, parser.eval("1 / 10 * 10 / 100"), EPSILON);
-        assertEquals(-89d, parser.eval("1 + 10 - 100"), EPSILON);
-        assertEquals(91d, parser.eval("1 - 10 - -100"), EPSILON);
-        assertEquals(91d, parser.eval("1 - 10  + 100"), EPSILON);
-        assertEquals(-109d, parser.eval("1 - (10 + 100)"), EPSILON);
-        assertEquals(-89d, parser.eval("1 + (10 - 100)"), EPSILON);
-        assertEquals(100d, parser.eval("1 / 1 * 100"), EPSILON);
-        assertEquals(0.01d, parser.eval("1 / (1 * 100)"), EPSILON);
-        assertEquals(0.01d, parser.eval("1 * 1 / 100"), EPSILON);
-        assertEquals(7d, parser.eval("3+4"), EPSILON);
-        assertEquals(7d, parser.eval("3      +    4"), EPSILON);
-        assertEquals(-1d, parser.eval("3+ -4"), EPSILON);
-        assertEquals(-1d, parser.eval("3+(-4)"), EPSILON);
+        assertEquals(0.01, parser.eval("1 / 10 * 10 / 100"), EPSILON);
+        assertEquals(-89, parser.eval("1 + 10 - 100"), EPSILON);
+        assertEquals(91, parser.eval("1 - 10 - -100"), EPSILON);
+        assertEquals(91, parser.eval("1 - 10  + 100"), EPSILON);
+        assertEquals(-109, parser.eval("1 - (10 + 100)"), EPSILON);
+        assertEquals(-89, parser.eval("1 + (10 - 100)"), EPSILON);
+        assertEquals(100, parser.eval("1 / 1 * 100"), EPSILON);
+        assertEquals(0.01, parser.eval("1 / (1 * 100)"), EPSILON);
+        assertEquals(0.01, parser.eval("1 * 1 / 100"), EPSILON);
+        assertEquals(7, parser.eval("3+4"), EPSILON);
+        assertEquals(7, parser.eval("3      +    4"), EPSILON);
+        assertEquals(-1, parser.eval("3+ -4"), EPSILON);
+        assertEquals(-1, parser.eval("3+(-4)"), EPSILON);
     }
 
     @Test
-    public void number() throws ParseException {
-        assertEquals(4003.333333d, parser.eval("3.333_333+4_000"), EPSILON);
+    public void testConstantNumbers() throws ParseException {
+        assertEquals(4003.333333, parser.eval("3.333_333+4_000"), EPSILON);
         assertEquals(0.03, parser.eval("3e-2"), EPSILON);
-        assertEquals(300d, parser.eval("3e2"), EPSILON);
-        assertEquals(300d, parser.eval("3e+2"), EPSILON);
-        assertEquals(320d, parser.eval("3.2e2"), EPSILON);
+        assertEquals(300, parser.eval("3e2"), EPSILON);
+        assertEquals(300, parser.eval("3e+2"), EPSILON);
+        assertEquals(320, parser.eval("3.2e2"), EPSILON);
         assertEquals(0.032, parser.eval("3.2e-2"), EPSILON);
         assertEquals(0.03, parser.eval("3E-2"), EPSILON);
-        assertEquals(300d, parser.eval("3E2"), EPSILON);
-        assertEquals(300d, parser.eval("3E+2"), EPSILON);
-        assertEquals(320d, parser.eval("3.2E2"), EPSILON);
+        assertEquals(300, parser.eval("3E2"), EPSILON);
+        assertEquals(300, parser.eval("3E+2"), EPSILON);
+        assertEquals(320, parser.eval("3.2E2"), EPSILON);
         assertEquals(0.032, parser.eval("3.2E-2"), EPSILON);
     }
 
     @Test
-    public void precedence() throws ParseException {
+    public void testOperatorPrecedence() throws ParseException {
         // term vs. product
-        assertEquals(19d, parser.eval("3+4*4"), EPSILON);
+        assertEquals(19, parser.eval("3+4*4"), EPSILON);
         // product vs. power
-        assertEquals(20.25d, parser.eval("3^4/4"), EPSILON);
+        assertEquals(20.25, parser.eval("3^4/4"), EPSILON);
         // relation vs. product
-        assertEquals(1d, parser.eval("3 < 4*4"), EPSILON);
-        assertEquals(0d, parser.eval("3 > 4*4"), EPSILON);
+        assertEquals(1, parser.eval("3 < 4*4"), EPSILON);
+        assertEquals(0, parser.eval("3 > 4*4"), EPSILON);
         // brackets
-        assertEquals(28d, parser.eval("(3 + 4) * 4"), EPSILON);
-        assertEquals(304d, parser.eval("3e2 + 4"), EPSILON);
-        assertEquals(1200d, parser.eval("3e2 * 4"), EPSILON);
+        assertEquals(28, parser.eval("(3 + 4) * 4"), EPSILON);
+        assertEquals(304, parser.eval("3e2 + 4"), EPSILON);
+        assertEquals(1200, parser.eval("3e2 * 4"), EPSILON);
     }
 
     @Test
-    public void signed() throws ParseException {
+    public void testSingedNumbers() throws ParseException {
         assertEquals(-2.02, parser.eval("-2.02"), EPSILON);
         assertEquals(2.02, parser.eval("+2.02"), EPSILON);
         assertEquals(1.01, parser.eval("+2.02 + -1.01"), EPSILON);
@@ -94,22 +94,22 @@ public class EvalTest {
     }
 
     @Test
-    public void blockComment() throws ParseException {
+    public void testBlockComment() throws ParseException {
         assertEquals(29, parser.eval("27+ /*xxx*/ 2"), EPSILON);
         assertEquals(29, parser.eval("27+/*xxx*/ 2"), EPSILON);
         assertEquals(29, parser.eval("27/*xxx*/+2"), EPSILON);
     }
 
     @Test
-    public void startingWithDecimalPoint() throws ParseException {
-        assertEquals(.2, parser.eval(".2"), EPSILON);
-        assertEquals(.2, parser.eval("+.2"), EPSILON);
-        assertEquals(.4, parser.eval(".2+.2"), EPSILON);
-        assertEquals(.4, parser.eval(".6+-.2"), EPSILON);
+    public void testNumberBeginningWithDecimalPoint() throws ParseException {
+        assertEquals(0.2, parser.eval(".2"), EPSILON);
+        assertEquals(0.2, parser.eval("+.2"), EPSILON);
+        assertEquals(0.4, parser.eval(".2+.2"), EPSILON);
+        assertEquals(0.4, parser.eval(".6+-.2"), EPSILON);
     }
 
     @Test
-    public void signedParentheses() throws ParseException {
+    public void testSignedParentheses() throws ParseException {
         assertEquals(0.2, parser.eval("-(-0.2)"), EPSILON);
         assertEquals(1.2, parser.eval("1-(-0.2)"), EPSILON);
         assertEquals(0.8, parser.eval("1+(-0.2)"), EPSILON);
@@ -117,12 +117,12 @@ public class EvalTest {
     }
 
     @Test
-    public void trailingDecimalPoint() throws ParseException {
-        assertEquals(2., parser.eval("2."), EPSILON);
+    public void testTrailingDecimalPoint() throws ParseException {
+        assertEquals(2.0, parser.eval("2."), EPSILON);
     }
 
     @Test
-    public void signedValueAfterOperand() throws ParseException {
+    public void testSignedValueAfterOperand() throws ParseException {
         assertEquals(-1.2, parser.eval("1+-2.2"), EPSILON);
         assertEquals(3.2, parser.eval("1++2.2"), EPSILON);
         assertEquals(6 * -1.1, parser.eval("6*-1.1"), EPSILON);
@@ -130,79 +130,55 @@ public class EvalTest {
     }
 
     @Test
-    public void variables() throws ParseException {
+    public void testScopeVariables() throws ParseException {
         Scope scope = new Scope();
 
         scope.create("a", 2);
         scope.create("b", 3);
         double result = parser.eval("3*a + 4 * b", scope);
 
-        assertEquals(18d, result, EPSILON);
-        assertEquals(18d, result, EPSILON);
+        assertEquals(18, result, EPSILON);
+        assertEquals(18, result, EPSILON);
     }
 
     @Test
-    public void functions() throws ParseException {
-        assertEquals(0d, parser.eval("1 + sin(-pi) + cos(pi)"), EPSILON);
-        assertEquals(4.72038341576d, parser.eval("tan(sqrt(euler ^ (pi * 3)))"), EPSILON);
-        assertEquals(3d, parser.eval("| 3 - 6 |"), EPSILON);
-        assertEquals(3d, parser.eval("if(3 > 2 && 2 < 3, 2+1, 1+1)"), EPSILON);
-        assertEquals(2d, parser.eval("if(3 < 2 || 2 > 3, 2+1, 1+1)"), EPSILON);
-        assertEquals(3d, parser.eval("if(1, 2+1, 1+1)"), EPSILON);
-        assertEquals(2d, parser.eval("if(0, 2+1, 1+1)"), EPSILON);
-        assertEquals(2d, parser.eval("min(3,2)"), EPSILON);
-        assertEquals(2d, parser.eval("abs(2)"), EPSILON);
-        assertEquals(2d, parser.eval("abs(-2)"), EPSILON);
-        assertEquals(-3d, parser.eval("floor(-2.2)"), EPSILON);
-        assertEquals(-2d, parser.eval("ceil(-2.2)"), EPSILON);
+    public void testFunctions() throws ParseException {
+        assertEquals(0, parser.eval("1 + sin(-pi) + cos(pi)"), EPSILON);
+        assertEquals(4.72038341576, parser.eval("tan(sqrt(euler ^ (pi * 3)))"), EPSILON);
+        assertEquals(3, parser.eval("| 3 - 6 |"), EPSILON);
+        assertEquals(3, parser.eval("if(3 > 2 && 2 < 3, 2+1, 1+1)"), EPSILON);
+        assertEquals(2, parser.eval("if(3 < 2 || 2 > 3, 2+1, 1+1)"), EPSILON);
+        assertEquals(3, parser.eval("if(1, 2+1, 1+1)"), EPSILON);
+        assertEquals(2, parser.eval("if(0, 2+1, 1+1)"), EPSILON);
+        assertEquals(2, parser.eval("min(3,2)"), EPSILON);
+        assertEquals(2, parser.eval("abs(2)"), EPSILON);
+        assertEquals(2, parser.eval("abs(-2)"), EPSILON);
+        assertEquals(-3, parser.eval("floor(-2.2)"), EPSILON);
+        assertEquals(-2, parser.eval("ceil(-2.2)"), EPSILON);
 
         Scope scope = new Scope();
         scope.addInvocationVariable("x");
-        assertEquals(1d, parser.eval("if(x, 0, 1)", scope, 0), EPSILON);
-        assertEquals(0d, parser.eval("if(x, 0, 1)", scope, 10), EPSILON);
+        assertEquals(1, parser.eval("if(x, 0, 1)", scope, 0), EPSILON);
+        assertEquals(0, parser.eval("if(x, 0, 1)", scope, 10), EPSILON);
 
 
         // Test a var arg method...
-        parser.registerFunction("avg", avgFun);
-        assertEquals(3.25d, parser.eval("avg(3,2,1,7)"), EPSILON);
+        parser.registerFunction("avg", new DynamicAverageFunction());
+        assertEquals(3.25, parser.eval("avg(3,2,1,7)"), EPSILON);
     }
 
-    DynamicFunction avgFun = new DynamicFunction() {
-        @Override
-        public int getArgNumber() {
-            return -1;
-        }
-
-        @Override
-        public double eval(double... args) {
-            double avg = 0;
-            if (args.length == 0) {
-                return avg;
-            }
-            for (double e : args) {
-                avg += e;
-            }
-            return avg / args.length;
-        }
-
-        @Override
-        public @NotNull Statefulness statefulness() {
-            return Statefulness.STATELESS;
-        }
-    };
-
     @Test
-    public void multiInstance() throws ParseException {
+    public void testMultiInstance() throws ParseException {
         Parser p2 = new Parser();
-        p2.registerFunction("avg", avgFun);
+        p2.registerFunction("avg", new DynamicAverageFunction());
         Parser p3 = new Parser();
-        p3.registerFunction("avg", avgFun);
-        assertEquals(3.25d, p2.eval("avg(3,2,1,7)"), EPSILON);
-        assertEquals(4.5d, p3.eval("avg(4,5,4,5)"), EPSILON);
+        p3.registerFunction("avg", new DynamicAverageFunction());
+        assertEquals(3.25, p2.eval("avg(3,2,1,7)"), EPSILON);
+        assertEquals(4.5, p3.eval("avg(4,5,4,5)"), EPSILON);
     }
 
     @Test
-    public void scopes() throws ParseException {
+    public void testScopes() throws ParseException {
         Scope root = new Scope();
         root.create("a", 1);
         Scope subScope1 = new Scope().withParent(root);
@@ -215,18 +191,16 @@ public class EvalTest {
         root.create("d", 9);
         subScope1.create("d", 7);
 
-        double expr1 = parser.eval("a + b + c + d", subScope1);
-        double expr2 = parser.eval("a + b + c + d", subScope2);
-        assertEquals(15d, expr1, EPSILON);
-        assertEquals(17d, expr2, EPSILON);
+        assertEquals(15, parser.eval("a + b + c + d", subScope1), EPSILON);
+        assertEquals(17, parser.eval("a + b + c + d", subScope2), EPSILON);
     }
 
     @Test
-    public void errors() {
+    public void testParsingErrors() {
         // We expect the parser to continue after an recoverable error!
         try {
             parser.eval("test(1 2)+sin(1,2)*34-34.45.45+");
-            fail();
+            fail("Evaluation should fail when an operator is missing an operand");
         } catch (ParseException e) {
             assertEquals(5, e.getErrors().size());
         }
@@ -234,7 +208,7 @@ public class EvalTest {
         // We expect the parser to report an invalid quantifier.
         try {
             parser.eval("1x");
-            fail();
+            fail("Evaluation should fail when an invalid quantifier is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -242,7 +216,7 @@ public class EvalTest {
         // We expect the parser to report an unfinished expression
         try {
             parser.eval("1(");
-            fail();
+            fail("Evaluation should fail when braces are not closed");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -250,7 +224,7 @@ public class EvalTest {
         // We expect the parser to report an unexpected separator.
         try {
             parser.eval("3ee3");
-            fail();
+            fail("Evaluation should fail when an unexpected separator is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -258,7 +232,7 @@ public class EvalTest {
         // We expect the parser to report an unexpected separator.
         try {
             parser.eval("3e3.3");
-            fail();
+            fail("Evaluation should fail when an unexpected separator is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -266,59 +240,59 @@ public class EvalTest {
         // We expect the parser to report an unexpected token.
         try {
             parser.eval("3e");
-            fail();
+            fail("Evaluation should fail when an unexpected token is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
     }
 
     @Test
-    public void relationalOperators() throws ParseException {
+    public void testRelationalOperators() throws ParseException {
         // Test for Issue with >= and <= operators (#4)
-        assertEquals(1d, parser.eval("5 <= 5"), EPSILON);
-        assertEquals(1d, parser.eval("5 >= 5"), EPSILON);
-        assertEquals(0d, parser.eval("5 < 5"), EPSILON);
-        assertEquals(0d, parser.eval("5 > 5"), EPSILON);
+        assertEquals(1, parser.eval("5 <= 5"), EPSILON);
+        assertEquals(1, parser.eval("5 >= 5"), EPSILON);
+        assertEquals(0, parser.eval("5 < 5"), EPSILON);
+        assertEquals(0, parser.eval("5 > 5"), EPSILON);
     }
 
     @Test
-    public void quantifiers() throws ParseException {
-        assertEquals(1000d, parser.eval("1K"), EPSILON);
-        assertEquals(1000d, parser.eval("1M * 1m"), EPSILON);
-        assertEquals(1d, parser.eval("1n * 1G"), EPSILON);
-        assertEquals(1d, parser.eval("(1M / 1k) * 1m"), EPSILON);
-        assertEquals(1d, parser.eval("1u * 10 k * 1000  m * 0.1 k"), EPSILON);
+    public void testQuantifiers() throws ParseException {
+        assertEquals(1000, parser.eval("1K"), EPSILON);
+        assertEquals(1000, parser.eval("1M * 1m"), EPSILON);
+        assertEquals(1, parser.eval("1n * 1G"), EPSILON);
+        assertEquals(1, parser.eval("(1M / 1k) * 1m"), EPSILON);
+        assertEquals(1, parser.eval("1u * 10 k * 1000  m * 0.1 k"), EPSILON);
     }
 
     @Test
-    public void errorOnUnknownVariable() throws ParseException {
-        Scope s = new Scope();
+    public void testParsingErrorOnUnknownVariable() throws ParseException {
+        Scope scope = new Scope();
         try {
-            s.create("a", 0);
-            s.create("b", 0);
-            parser.eval("a*b+c", s);
+            scope.create("a", 0);
+            scope.create("b", 0);
+            parser.eval("a*b+c", scope);
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
 
-        s.create("c", 0);
-        parser.eval("a*b+c", s);
+        scope.create("c", 0);
+        parser.eval("a*b+c", scope);
     }
 
     @Test
-    public void removeVariable() {
-        Scope s = new Scope();
-        s.create("X", 0);
-        assertNotNull(s.find("X"));
-        assertNotNull(s.remove("X"));
-        assertNull(s.find("X"));
+    public void testRemoveScopeVariable() {
+        Scope scope = new Scope();
+        scope.create("X", 0);
+        assertNotNull(scope.find("X"));
+        assertNotNull(scope.remove("X"));
+        assertNull(scope.find("X"));
     }
 
     @Test
-    public void removeVariableFromSubscope() {
-        Scope s = new Scope();
-        Scope child = new Scope().withParent(s);
-        s.create("X", 0);
+    public void testRemoveVariableFromSubscope() {
+        Scope scope = new Scope();
+        Scope child = new Scope().withParent(scope);
+        scope.create("X", 0);
         assertNotNull(child.find("X"));
         assertNull(child.remove("X"));
         assertNotNull(child.find("X"));
@@ -333,8 +307,9 @@ public class EvalTest {
                 return 0;
             }
 
+            @NotNull
             @Override
-            public @NotNull Statefulness statefulness() {
+            public Statefulness statefulness() {
                 return Statefulness.STATELESS;
             }
 
@@ -345,17 +320,35 @@ public class EvalTest {
 
             @Override
             public double eval(Context context, double... args) {
-                assertEquals(context, Expression.DEFAULT_CONTEXT);
-                System.out.println(context);
+                assertEquals(Expression.DEFAULT_CONTEXT, context);
                 return DynamicFunction.super.eval(context, args);
             }
         });
         parser.eval("test()");
     }
 
-    private static final class CustomContext implements Context {
-        public String getBazinga() {
-            return "bazinga";
+    private static class DynamicAverageFunction implements DynamicFunction {
+        @Override
+        public int getArgNumber() {
+            return -1;
+        }
+
+        @NotNull
+        @Override
+        public Statefulness statefulness() {
+            return Statefulness.STATELESS;
+        }
+
+        @Override
+        public double eval(double... args) {
+            double avg = 0;
+            if (args.length == 0) {
+                return avg;
+            }
+            for (double e : args) {
+                avg += e;
+            }
+            return avg / args.length;
         }
     }
 }

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -14,9 +14,9 @@ import com.dfsek.paralithic.functions.dynamic.Context;
 import com.dfsek.paralithic.functions.dynamic.DynamicFunction;
 import com.dfsek.paralithic.node.Statefulness;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -39,68 +39,68 @@ public class ParserTest {
     }
 
     @Test
-    public void optimisations() throws ParseException {
+    public void testOptimisations() throws ParseException {
         // we need a scope to avoid constant folding for some ops.
-        assertEquals(2d, parser.parse("pow(x, 0.5)", singleVariableScope).evaluate(4), EPSILON);
-        assertEquals(4d, parser.parse("pow(x, 2)", singleVariableScope).evaluate(2), EPSILON);
-        assertEquals(8d, parser.parse("pow(x, 3)", singleVariableScope).evaluate(2), EPSILON);
-        assertEquals(1d, parser.parse("pow(x, 0)", singleVariableScope).evaluate(20), EPSILON);
-        assertEquals(0.5d, parser.parse("pow(x, -1)", singleVariableScope).evaluate(2), EPSILON);
-        assertEquals(0d, parser.parse("pow(0, x)", singleVariableScope).evaluate(20), EPSILON);
+        assertEquals(2, parser.parse("pow(x, 0.5)", singleVariableScope).evaluate(4), EPSILON);
+        assertEquals(4, parser.parse("pow(x, 2)", singleVariableScope).evaluate(2), EPSILON);
+        assertEquals(8, parser.parse("pow(x, 3)", singleVariableScope).evaluate(2), EPSILON);
+        assertEquals(1, parser.parse("pow(x, 0)", singleVariableScope).evaluate(20), EPSILON);
+        assertEquals(0.5, parser.parse("pow(x, -1)", singleVariableScope).evaluate(2), EPSILON);
+        assertEquals(0, parser.parse("pow(0, x)", singleVariableScope).evaluate(20), EPSILON);
     }
 
 
     @Test
-    public void simple() throws ParseException {
-        assertEquals(-109d, parser.parse("1 - (10 - -100)").evaluate(), EPSILON);
+    public void testSimpleExpressions() throws ParseException {
+        assertEquals(-109, parser.parse("1 - (10 - -100)").evaluate(), EPSILON);
         assertEquals(10, parser.parse("1 + 2 + 3 + 4").evaluate(), EPSILON);
-        assertEquals(0.01d, parser.parse("1 / 10 * 10 / 100").evaluate(), EPSILON);
-        assertEquals(-89d, parser.parse("1 + 10 - 100").evaluate(), EPSILON);
-        assertEquals(91d, parser.parse("1 - 10 - -100").evaluate(), EPSILON);
-        assertEquals(91d, parser.parse("1 - 10  + 100").evaluate(), EPSILON);
-        assertEquals(-109d, parser.parse("1 - (10 + 100)").evaluate(), EPSILON);
-        assertEquals(-89d, parser.parse("1 + (10 - 100)").evaluate(), EPSILON);
-        assertEquals(100d, parser.parse("1 / 1 * 100").evaluate(), EPSILON);
-        assertEquals(0.01d, parser.parse("1 / (1 * 100)").evaluate(), EPSILON);
-        assertEquals(0.01d, parser.parse("1 * 1 / 100").evaluate(), EPSILON);
-        assertEquals(7d, parser.parse("3+4").evaluate(), EPSILON);
-        assertEquals(7d, parser.parse("3      +    4").evaluate(), EPSILON);
-        assertEquals(-1d, parser.parse("3+ -4").evaluate(), EPSILON);
-        assertEquals(-1d, parser.parse("3+(-4)").evaluate(), EPSILON);
+        assertEquals(0.01, parser.parse("1 / 10 * 10 / 100").evaluate(), EPSILON);
+        assertEquals(-89, parser.parse("1 + 10 - 100").evaluate(), EPSILON);
+        assertEquals(91, parser.parse("1 - 10 - -100").evaluate(), EPSILON);
+        assertEquals(91, parser.parse("1 - 10  + 100").evaluate(), EPSILON);
+        assertEquals(-109, parser.parse("1 - (10 + 100)").evaluate(), EPSILON);
+        assertEquals(-89, parser.parse("1 + (10 - 100)").evaluate(), EPSILON);
+        assertEquals(100, parser.parse("1 / 1 * 100").evaluate(), EPSILON);
+        assertEquals(0.01, parser.parse("1 / (1 * 100)").evaluate(), EPSILON);
+        assertEquals(0.01, parser.parse("1 * 1 / 100").evaluate(), EPSILON);
+        assertEquals(7, parser.parse("3+4").evaluate(), EPSILON);
+        assertEquals(7, parser.parse("3      +    4").evaluate(), EPSILON);
+        assertEquals(-1, parser.parse("3+ -4").evaluate(), EPSILON);
+        assertEquals(-1, parser.parse("3+(-4)").evaluate(), EPSILON);
     }
 
     @Test
-    public void number() throws ParseException {
-        assertEquals(4003.333333d, parser.parse("3.333_333+4_000").evaluate(), EPSILON);
+    public void testConstantNumbers() throws ParseException {
+        assertEquals(4003.333333, parser.parse("3.333_333+4_000").evaluate(), EPSILON);
         assertEquals(0.03, parser.parse("3e-2").evaluate(), EPSILON);
-        assertEquals(300d, parser.parse("3e2").evaluate(), EPSILON);
-        assertEquals(300d, parser.parse("3e+2").evaluate(), EPSILON);
-        assertEquals(320d, parser.parse("3.2e2").evaluate(), EPSILON);
+        assertEquals(300, parser.parse("3e2").evaluate(), EPSILON);
+        assertEquals(300, parser.parse("3e+2").evaluate(), EPSILON);
+        assertEquals(320, parser.parse("3.2e2").evaluate(), EPSILON);
         assertEquals(0.032, parser.parse("3.2e-2").evaluate(), EPSILON);
         assertEquals(0.03, parser.parse("3E-2").evaluate(), EPSILON);
-        assertEquals(300d, parser.parse("3E2").evaluate(), EPSILON);
-        assertEquals(300d, parser.parse("3E+2").evaluate(), EPSILON);
-        assertEquals(320d, parser.parse("3.2E2").evaluate(), EPSILON);
+        assertEquals(300, parser.parse("3E2").evaluate(), EPSILON);
+        assertEquals(300, parser.parse("3E+2").evaluate(), EPSILON);
+        assertEquals(320, parser.parse("3.2E2").evaluate(), EPSILON);
         assertEquals(0.032, parser.parse("3.2E-2").evaluate(), EPSILON);
     }
 
     @Test
-    public void precedence() throws ParseException {
+    public void testOperatorPrecedence() throws ParseException {
         // term vs. product
-        assertEquals(19d, parser.parse("3+4*4").evaluate(), EPSILON);
+        assertEquals(19, parser.parse("3+4*4").evaluate(), EPSILON);
         // product vs. power
-        assertEquals(20.25d, parser.parse("3^4/4").evaluate(), EPSILON);
+        assertEquals(20.25, parser.parse("3^4/4").evaluate(), EPSILON);
         // relation vs. product
-        assertEquals(1d, parser.parse("3 < 4*4").evaluate(), EPSILON);
-        assertEquals(0d, parser.parse("3 > 4*4").evaluate(), EPSILON);
+        assertEquals(1, parser.parse("3 < 4*4").evaluate(), EPSILON);
+        assertEquals(0, parser.parse("3 > 4*4").evaluate(), EPSILON);
         // brackets
-        assertEquals(28d, parser.parse("(3 + 4) * 4").evaluate(), EPSILON);
-        assertEquals(304d, parser.parse("3e2 + 4").evaluate(), EPSILON);
-        assertEquals(1200d, parser.parse("3e2 * 4").evaluate(), EPSILON);
+        assertEquals(28, parser.parse("(3 + 4) * 4").evaluate(), EPSILON);
+        assertEquals(304, parser.parse("3e2 + 4").evaluate(), EPSILON);
+        assertEquals(1200, parser.parse("3e2 * 4").evaluate(), EPSILON);
     }
 
     @Test
-    public void signed() throws ParseException {
+    public void testSingedNumbers() throws ParseException {
         assertEquals(-2.02, parser.parse("-2.02").evaluate(), EPSILON);
         assertEquals(2.02, parser.parse("+2.02").evaluate(), EPSILON);
         assertEquals(1.01, parser.parse("+2.02 + -1.01").evaluate(), EPSILON);
@@ -109,22 +109,22 @@ public class ParserTest {
     }
 
     @Test
-    public void blockComment() throws ParseException {
+    public void testBlockComment() throws ParseException {
         assertEquals(29, parser.parse("27+ /*xxx*/ 2").evaluate(), EPSILON);
         assertEquals(29, parser.parse("27+/*xxx*/ 2").evaluate(), EPSILON);
         assertEquals(29, parser.parse("27/*xxx*/+2").evaluate(), EPSILON);
     }
 
     @Test
-    public void startingWithDecimalPoint() throws ParseException {
-        assertEquals(.2, parser.parse(".2").evaluate(), EPSILON);
-        assertEquals(.2, parser.parse("+.2").evaluate(), EPSILON);
-        assertEquals(.4, parser.parse(".2+.2").evaluate(), EPSILON);
-        assertEquals(.4, parser.parse(".6+-.2").evaluate(), EPSILON);
+    public void testNumberBeginningWithDecimalPoint() throws ParseException {
+        assertEquals(0.2, parser.parse(".2").evaluate(), EPSILON);
+        assertEquals(0.2, parser.parse("+.2").evaluate(), EPSILON);
+        assertEquals(0.4, parser.parse(".2+.2").evaluate(), EPSILON);
+        assertEquals(0.4, parser.parse(".6+-.2").evaluate(), EPSILON);
     }
 
     @Test
-    public void signedParentheses() throws ParseException {
+    public void testSignedParentheses() throws ParseException {
         assertEquals(0.2, parser.parse("-(-0.2)").evaluate(), EPSILON);
         assertEquals(1.2, parser.parse("1-(-0.2)").evaluate(), EPSILON);
         assertEquals(0.8, parser.parse("1+(-0.2)").evaluate(), EPSILON);
@@ -132,12 +132,12 @@ public class ParserTest {
     }
 
     @Test
-    public void trailingDecimalPoint() throws ParseException {
-        assertEquals(2., parser.parse("2.").evaluate(), EPSILON);
+    public void testTrailingDecimalPoint() throws ParseException {
+        assertEquals(2.0, parser.parse("2.").evaluate(), EPSILON);
     }
 
     @Test
-    public void signedValueAfterOperand() throws ParseException {
+    public void testSignedValueAfterOperand() throws ParseException {
         assertEquals(-1.2, parser.parse("1+-2.2").evaluate(), EPSILON);
         assertEquals(3.2, parser.parse("1++2.2").evaluate(), EPSILON);
         assertEquals(6 * -1.1, parser.parse("6*-1.1").evaluate(), EPSILON);
@@ -145,77 +145,53 @@ public class ParserTest {
     }
 
     @Test
-    public void variables() throws ParseException {
+    public void testScopeVariables() throws ParseException {
         Scope scope = new Scope();
 
         scope.create("a", 2);
         scope.create("b", 3);
         Expression expr = parser.parse("3*a + 4 * b", scope);
 
-        assertEquals(18d, expr.evaluate(), EPSILON);
-        assertEquals(18d, expr.evaluate(), EPSILON);
+        assertEquals(18, expr.evaluate(), EPSILON);
+        assertEquals(18, expr.evaluate(), EPSILON);
     }
 
     @Test
-    public void functions() throws ParseException {
-        assertEquals(0d, parser.parse("1 + sin(-pi) + cos(pi)").evaluate(), EPSILON);
-        assertEquals(4.72038341576d, parser.parse("tan(sqrt(euler ^ (pi * 3)))").evaluate(), EPSILON);
-        assertEquals(3d, parser.parse("| 3 - 6 |").evaluate(), EPSILON);
-        assertEquals(3d, parser.parse("if(3 > 2 && 2 < 3, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(2d, parser.parse("if(3 < 2 || 2 > 3, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(3d, parser.parse("if(1, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(2d, parser.parse("if(0, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(2d, parser.parse("min(3,2)").evaluate(), EPSILON);
-        assertEquals(2d, parser.parse("abs(2)").evaluate(), EPSILON);
-        assertEquals(2d, parser.parse("abs(-2)").evaluate(), EPSILON);
-        assertEquals(-3d, parser.parse("floor(-2.2)").evaluate(), EPSILON);
-        assertEquals(-2d, parser.parse("ceil(-2.2)").evaluate(), EPSILON);
+    public void testFunctions() throws ParseException {
+        assertEquals(0, parser.parse("1 + sin(-pi) + cos(pi)").evaluate(), EPSILON);
+        assertEquals(4.72038341576, parser.parse("tan(sqrt(euler ^ (pi * 3)))").evaluate(), EPSILON);
+        assertEquals(3, parser.parse("| 3 - 6 |").evaluate(), EPSILON);
+        assertEquals(3, parser.parse("if(3 > 2 && 2 < 3, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(2, parser.parse("if(3 < 2 || 2 > 3, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(3, parser.parse("if(1, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(2, parser.parse("if(0, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(2, parser.parse("min(3,2)").evaluate(), EPSILON);
+        assertEquals(2, parser.parse("abs(2)").evaluate(), EPSILON);
+        assertEquals(2, parser.parse("abs(-2)").evaluate(), EPSILON);
+        assertEquals(-3, parser.parse("floor(-2.2)").evaluate(), EPSILON);
+        assertEquals(-2, parser.parse("ceil(-2.2)").evaluate(), EPSILON);
 
-        assertEquals(1d, parser.parse("if(x, 0, 1)", singleVariableScope).evaluate(0), EPSILON);
-        assertEquals(0d, parser.parse("if(x, 0, 1)", singleVariableScope).evaluate(10), EPSILON);
+        assertEquals(1, parser.parse("if(x, 0, 1)", singleVariableScope).evaluate(0), EPSILON);
+        assertEquals(0, parser.parse("if(x, 0, 1)", singleVariableScope).evaluate(10), EPSILON);
 
 
         // Test a var arg method...
-        parser.registerFunction("avg", avgFun);
-        assertEquals(3.25d, parser.parse("avg(3,2,1,7)").evaluate(), EPSILON);
+        parser.registerFunction("avg", new DynamicAverageFunction());
+        assertEquals(3.25, parser.parse("avg(3,2,1,7)").evaluate(), EPSILON);
     }
 
-    DynamicFunction avgFun = new DynamicFunction() {
-        @Override
-        public int getArgNumber() {
-            return -1;
-        }
-
-        @Override
-        public double eval(double... args) {
-            double avg = 0;
-            if (args.length == 0) {
-                return avg;
-            }
-            for (double e : args) {
-                avg += e;
-            }
-            return avg / args.length;
-        }
-
-        @Override
-        public @NotNull Statefulness statefulness() {
-            return Statefulness.STATELESS;
-        }
-    };
-
     @Test
-    public void multiInstance() throws ParseException {
+    public void testMultiInstance() throws ParseException {
         Parser p2 = new Parser();
-        p2.registerFunction("avg", avgFun);
+        p2.registerFunction("avg", new DynamicAverageFunction());
         Parser p3 = new Parser();
-        p3.registerFunction("avg", avgFun);
-        assertEquals(3.25d, p2.parse("avg(3,2,1,7)").evaluate(), EPSILON);
-        assertEquals(4.5d, p3.parse("avg(4,5,4,5)").evaluate(), EPSILON);
+        p3.registerFunction("avg", new DynamicAverageFunction());
+        assertEquals(3.25, p2.parse("avg(3,2,1,7)").evaluate(), EPSILON);
+        assertEquals(4.5, p3.parse("avg(4,5,4,5)").evaluate(), EPSILON);
     }
 
     @Test
-    public void scopes() throws ParseException {
+    public void testScopes() throws ParseException {
         Scope root = new Scope();
         root.create("a", 1);
         Scope subScope1 = new Scope().withParent(root);
@@ -228,18 +204,16 @@ public class ParserTest {
         root.create("d", 9);
         subScope1.create("d", 7);
 
-        Expression expr1 = parser.parse("a + b + c + d", subScope1);
-        Expression expr2 = parser.parse("a + b + c + d", subScope2);
-        assertEquals(15d, expr1.evaluate(), EPSILON);
-        assertEquals(17d, expr2.evaluate(), EPSILON);
+        assertEquals(15, parser.parse("a + b + c + d", subScope1).evaluate(), EPSILON);
+        assertEquals(17, parser.parse("a + b + c + d", subScope2).evaluate(), EPSILON);
     }
 
     @Test
-    public void errors() {
+    public void testParsingErrors() {
         // We expect the parser to continue after an recoverable error!
         try {
             parser.parse("test(1 2)+sin(1,2)*34-34.45.45+");
-            fail();
+            fail("Evaluation should fail when an operator is missing an operand");
         } catch (ParseException e) {
             assertEquals(5, e.getErrors().size());
         }
@@ -247,7 +221,7 @@ public class ParserTest {
         // We expect the parser to report an invalid quantifier.
         try {
             parser.parse("1x");
-            fail();
+            fail("Evaluation should fail when an invalid quantifier is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -255,7 +229,7 @@ public class ParserTest {
         // We expect the parser to report an unfinished expression
         try {
             parser.parse("1(");
-            fail();
+            fail("Evaluation should fail when braces are not closed");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -263,7 +237,7 @@ public class ParserTest {
         // We expect the parser to report an unexpected separator.
         try {
             parser.parse("3ee3");
-            fail();
+            fail("Evaluation should fail when an unexpected separator is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -271,7 +245,7 @@ public class ParserTest {
         // We expect the parser to report an unexpected separator.
         try {
             parser.parse("3e3.3");
-            fail();
+            fail("Evaluation should fail when an unexpected separator is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
@@ -279,59 +253,59 @@ public class ParserTest {
         // We expect the parser to report an unexpected token.
         try {
             parser.parse("3e");
-            fail();
+            fail("Evaluation should fail when an unexpected token is encountered");
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
     }
 
     @Test
-    public void relationalOperators() throws ParseException {
+    public void testRelationalOperators() throws ParseException {
         // Test for Issue with >= and <= operators (#4)
-        assertEquals(1d, parser.parse("5 <= 5").evaluate(), EPSILON);
-        assertEquals(1d, parser.parse("5 >= 5").evaluate(), EPSILON);
-        assertEquals(0d, parser.parse("5 < 5").evaluate(), EPSILON);
-        assertEquals(0d, parser.parse("5 > 5").evaluate(), EPSILON);
+        assertEquals(1, parser.parse("5 <= 5").evaluate(), EPSILON);
+        assertEquals(1, parser.parse("5 >= 5").evaluate(), EPSILON);
+        assertEquals(0, parser.parse("5 < 5").evaluate(), EPSILON);
+        assertEquals(0, parser.parse("5 > 5").evaluate(), EPSILON);
     }
 
     @Test
-    public void quantifiers() throws ParseException {
-        assertEquals(1000d, parser.parse("1K").evaluate(), EPSILON);
-        assertEquals(1000d, parser.parse("1M * 1m").evaluate(), EPSILON);
-        assertEquals(1d, parser.parse("1n * 1G").evaluate(), EPSILON);
-        assertEquals(1d, parser.parse("(1M / 1k) * 1m").evaluate(), EPSILON);
-        assertEquals(1d, parser.parse("1u * 10 k * 1000  m * 0.1 k").evaluate(), EPSILON);
+    public void testQuantifiers() throws ParseException {
+        assertEquals(1000, parser.parse("1K").evaluate(), EPSILON);
+        assertEquals(1000, parser.parse("1M * 1m").evaluate(), EPSILON);
+        assertEquals(1, parser.parse("1n * 1G").evaluate(), EPSILON);
+        assertEquals(1, parser.parse("(1M / 1k) * 1m").evaluate(), EPSILON);
+        assertEquals(1, parser.parse("1u * 10 k * 1000  m * 0.1 k").evaluate(), EPSILON);
     }
 
     @Test
-    public void errorOnUnknownVariable() throws ParseException {
-        Scope s = new Scope();
+    public void testParsingErrorOnUnknownVariable() throws ParseException {
+        Scope scope = new Scope();
         try {
-            s.create("a", 0);
-            s.create("b", 0);
-            parser.parse("a*b+c", s);
+            scope.create("a", 0);
+            scope.create("b", 0);
+            parser.parse("a*b+c", scope);
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
 
-        s.create("c", 0);
-        parser.parse("a*b+c", s);
+        scope.create("c", 0);
+        parser.parse("a*b+c", scope);
     }
 
     @Test
-    public void removeVariable() {
-        Scope s = new Scope();
-        s.create("X", 0);
-        assertNotNull(s.find("X"));
-        assertNotNull(s.remove("X"));
-        assertNull(s.find("X"));
+    public void testRemoveScopeVariable() {
+        Scope scope = new Scope();
+        scope.create("X", 0);
+        assertNotNull(scope.find("X"));
+        assertNotNull(scope.remove("X"));
+        assertNull(scope.find("X"));
     }
 
     @Test
-    public void removeVariableFromSubscope() {
-        Scope s = new Scope();
-        Scope child = new Scope().withParent(s);
-        s.create("X", 0);
+    public void testRemoveVariableFromSubscope() {
+        Scope scope = new Scope();
+        Scope child = new Scope().withParent(scope);
+        scope.create("X", 0);
         assertNotNull(child.find("X"));
         assertNull(child.remove("X"));
         assertNotNull(child.find("X"));
@@ -346,8 +320,9 @@ public class ParserTest {
                 return 0;
             }
 
+            @NotNull
             @Override
-            public @NotNull Statefulness statefulness() {
+            public Statefulness statefulness() {
                 return Statefulness.STATELESS;
             }
 
@@ -358,8 +333,7 @@ public class ParserTest {
 
             @Override
             public double eval(Context context, double... args) {
-                assertEquals(context, Expression.DEFAULT_CONTEXT);
-                System.out.println(context);
+                assertEquals(Expression.DEFAULT_CONTEXT, context);
                 return DynamicFunction.super.eval(context, args);
             }
         });
@@ -387,18 +361,42 @@ public class ParserTest {
 
             @Override
             public double eval(Context context, double... args) {
-                assertTrue(context instanceof CustomContext);
-                System.out.println(((CustomContext) context).getBazinga());
-                System.out.println(context);
+                assertInstanceOf(CustomContext.class, context);
+                assertDoesNotThrow(() -> assertEquals("bazinga", ((CustomContext) context).getBazinga()));
                 return DynamicFunction.super.eval(context, args);
             }
         });
-        parser.parse("test()").evaluate(new CustomContext());
+        assertEquals(0, parser.parse("test()").evaluate(new CustomContext()));
     }
 
     private static final class CustomContext implements Context {
         public String getBazinga() {
             return "bazinga";
+        }
+    }
+
+    private static final class DynamicAverageFunction implements DynamicFunction {
+        @Override
+        public int getArgNumber() {
+            return -1;
+        }
+
+        @NotNull
+        @Override
+        public Statefulness statefulness() {
+            return Statefulness.STATELESS;
+        }
+
+        @Override
+        public double eval(double... args) {
+            double avg = 0;
+            if (args.length == 0) {
+                return avg;
+            }
+            for (double e : args) {
+                avg += e;
+            }
+            return avg / args.length;
         }
     }
 }

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -14,6 +14,7 @@ import com.dfsek.paralithic.functions.dynamic.Context;
 import com.dfsek.paralithic.functions.dynamic.DynamicFunction;
 import com.dfsek.paralithic.node.Statefulness;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,118 +27,121 @@ import static org.junit.jupiter.api.Assertions.*;
  * @since 2013/09
  */
 public class ParserTest {
-    private static final Parser p;
     private static final double EPSILON = 1.0E-5;
+    private Parser parser;
+    private Scope singleVariableScope;
 
-    static {
-        p = new Parser();
+    @BeforeEach
+    public void setup() {
+        parser = new Parser();
+        singleVariableScope = new Scope();
+        singleVariableScope.addInvocationVariable("x"); // we need this to avoid constant folding for some ops.
     }
 
     @Test
     public void optimisations() throws ParseException {
-        Scope s = new Scope();
-        s.addInvocationVariable("x"); // we need this to avoid constant folding for some ops.
-        assertEquals(2d, p.parse("pow(x, 0.5)", s).evaluate(4), EPSILON);
-        assertEquals(4d, p.parse("pow(x, 2)", s).evaluate(2), EPSILON);
-        assertEquals(8d, p.parse("pow(x, 3)", s).evaluate(2), EPSILON);
-        assertEquals(1d, p.parse("pow(x, 0)", s).evaluate(20), EPSILON);
-        assertEquals(0.5d, p.parse("pow(x, -1)", s).evaluate(2), EPSILON);
-        assertEquals(0d, p.parse("pow(0, x)", s).evaluate(20), EPSILON);
+        // we need a scope to avoid constant folding for some ops.
+        assertEquals(2d, parser.parse("pow(x, 0.5)", singleVariableScope).evaluate(4), EPSILON);
+        assertEquals(4d, parser.parse("pow(x, 2)", singleVariableScope).evaluate(2), EPSILON);
+        assertEquals(8d, parser.parse("pow(x, 3)", singleVariableScope).evaluate(2), EPSILON);
+        assertEquals(1d, parser.parse("pow(x, 0)", singleVariableScope).evaluate(20), EPSILON);
+        assertEquals(0.5d, parser.parse("pow(x, -1)", singleVariableScope).evaluate(2), EPSILON);
+        assertEquals(0d, parser.parse("pow(0, x)", singleVariableScope).evaluate(20), EPSILON);
     }
 
 
     @Test
     public void simple() throws ParseException {
-        assertEquals(-109d, p.parse("1 - (10 - -100)").evaluate(), EPSILON);
-        assertEquals(10, p.parse("1 + 2 + 3 + 4").evaluate(), EPSILON);
-        assertEquals(0.01d, p.parse("1 / 10 * 10 / 100").evaluate(), EPSILON);
-        assertEquals(-89d, p.parse("1 + 10 - 100").evaluate(), EPSILON);
-        assertEquals(91d, p.parse("1 - 10 - -100").evaluate(), EPSILON);
-        assertEquals(91d, p.parse("1 - 10  + 100").evaluate(), EPSILON);
-        assertEquals(-109d, p.parse("1 - (10 + 100)").evaluate(), EPSILON);
-        assertEquals(-89d, p.parse("1 + (10 - 100)").evaluate(), EPSILON);
-        assertEquals(100d, p.parse("1 / 1 * 100").evaluate(), EPSILON);
-        assertEquals(0.01d, p.parse("1 / (1 * 100)").evaluate(), EPSILON);
-        assertEquals(0.01d, p.parse("1 * 1 / 100").evaluate(), EPSILON);
-        assertEquals(7d, p.parse("3+4").evaluate(), EPSILON);
-        assertEquals(7d, p.parse("3      +    4").evaluate(), EPSILON);
-        assertEquals(-1d, p.parse("3+ -4").evaluate(), EPSILON);
-        assertEquals(-1d, p.parse("3+(-4)").evaluate(), EPSILON);
+        assertEquals(-109d, parser.parse("1 - (10 - -100)").evaluate(), EPSILON);
+        assertEquals(10, parser.parse("1 + 2 + 3 + 4").evaluate(), EPSILON);
+        assertEquals(0.01d, parser.parse("1 / 10 * 10 / 100").evaluate(), EPSILON);
+        assertEquals(-89d, parser.parse("1 + 10 - 100").evaluate(), EPSILON);
+        assertEquals(91d, parser.parse("1 - 10 - -100").evaluate(), EPSILON);
+        assertEquals(91d, parser.parse("1 - 10  + 100").evaluate(), EPSILON);
+        assertEquals(-109d, parser.parse("1 - (10 + 100)").evaluate(), EPSILON);
+        assertEquals(-89d, parser.parse("1 + (10 - 100)").evaluate(), EPSILON);
+        assertEquals(100d, parser.parse("1 / 1 * 100").evaluate(), EPSILON);
+        assertEquals(0.01d, parser.parse("1 / (1 * 100)").evaluate(), EPSILON);
+        assertEquals(0.01d, parser.parse("1 * 1 / 100").evaluate(), EPSILON);
+        assertEquals(7d, parser.parse("3+4").evaluate(), EPSILON);
+        assertEquals(7d, parser.parse("3      +    4").evaluate(), EPSILON);
+        assertEquals(-1d, parser.parse("3+ -4").evaluate(), EPSILON);
+        assertEquals(-1d, parser.parse("3+(-4)").evaluate(), EPSILON);
     }
 
     @Test
     public void number() throws ParseException {
-        assertEquals(4003.333333d, p.parse("3.333_333+4_000").evaluate(), EPSILON);
-        assertEquals(0.03, p.parse("3e-2").evaluate(), EPSILON);
-        assertEquals(300d, p.parse("3e2").evaluate(), EPSILON);
-        assertEquals(300d, p.parse("3e+2").evaluate(), EPSILON);
-        assertEquals(320d, p.parse("3.2e2").evaluate(), EPSILON);
-        assertEquals(0.032, p.parse("3.2e-2").evaluate(), EPSILON);
-        assertEquals(0.03, p.parse("3E-2").evaluate(), EPSILON);
-        assertEquals(300d, p.parse("3E2").evaluate(), EPSILON);
-        assertEquals(300d, p.parse("3E+2").evaluate(), EPSILON);
-        assertEquals(320d, p.parse("3.2E2").evaluate(), EPSILON);
-        assertEquals(0.032, p.parse("3.2E-2").evaluate(), EPSILON);
+        assertEquals(4003.333333d, parser.parse("3.333_333+4_000").evaluate(), EPSILON);
+        assertEquals(0.03, parser.parse("3e-2").evaluate(), EPSILON);
+        assertEquals(300d, parser.parse("3e2").evaluate(), EPSILON);
+        assertEquals(300d, parser.parse("3e+2").evaluate(), EPSILON);
+        assertEquals(320d, parser.parse("3.2e2").evaluate(), EPSILON);
+        assertEquals(0.032, parser.parse("3.2e-2").evaluate(), EPSILON);
+        assertEquals(0.03, parser.parse("3E-2").evaluate(), EPSILON);
+        assertEquals(300d, parser.parse("3E2").evaluate(), EPSILON);
+        assertEquals(300d, parser.parse("3E+2").evaluate(), EPSILON);
+        assertEquals(320d, parser.parse("3.2E2").evaluate(), EPSILON);
+        assertEquals(0.032, parser.parse("3.2E-2").evaluate(), EPSILON);
     }
 
     @Test
     public void precedence() throws ParseException {
         // term vs. product
-        assertEquals(19d, p.parse("3+4*4").evaluate(), EPSILON);
+        assertEquals(19d, parser.parse("3+4*4").evaluate(), EPSILON);
         // product vs. power
-        assertEquals(20.25d, p.parse("3^4/4").evaluate(), EPSILON);
+        assertEquals(20.25d, parser.parse("3^4/4").evaluate(), EPSILON);
         // relation vs. product
-        assertEquals(1d, p.parse("3 < 4*4").evaluate(), EPSILON);
-        assertEquals(0d, p.parse("3 > 4*4").evaluate(), EPSILON);
+        assertEquals(1d, parser.parse("3 < 4*4").evaluate(), EPSILON);
+        assertEquals(0d, parser.parse("3 > 4*4").evaluate(), EPSILON);
         // brackets
-        assertEquals(28d, p.parse("(3 + 4) * 4").evaluate(), EPSILON);
-        assertEquals(304d, p.parse("3e2 + 4").evaluate(), EPSILON);
-        assertEquals(1200d, p.parse("3e2 * 4").evaluate(), EPSILON);
+        assertEquals(28d, parser.parse("(3 + 4) * 4").evaluate(), EPSILON);
+        assertEquals(304d, parser.parse("3e2 + 4").evaluate(), EPSILON);
+        assertEquals(1200d, parser.parse("3e2 * 4").evaluate(), EPSILON);
     }
 
     @Test
     public void signed() throws ParseException {
-        assertEquals(-2.02, p.parse("-2.02").evaluate(), EPSILON);
-        assertEquals(2.02, p.parse("+2.02").evaluate(), EPSILON);
-        assertEquals(1.01, p.parse("+2.02 + -1.01").evaluate(), EPSILON);
-        assertEquals(-4.03, p.parse("-2.02 - +2.01").evaluate(), EPSILON);
-        assertEquals(3.03, p.parse("+2.02 + +1.01").evaluate(), EPSILON);
+        assertEquals(-2.02, parser.parse("-2.02").evaluate(), EPSILON);
+        assertEquals(2.02, parser.parse("+2.02").evaluate(), EPSILON);
+        assertEquals(1.01, parser.parse("+2.02 + -1.01").evaluate(), EPSILON);
+        assertEquals(-4.03, parser.parse("-2.02 - +2.01").evaluate(), EPSILON);
+        assertEquals(3.03, parser.parse("+2.02 + +1.01").evaluate(), EPSILON);
     }
 
     @Test
     public void blockComment() throws ParseException {
-        assertEquals(29, p.parse("27+ /*xxx*/ 2").evaluate(), EPSILON);
-        assertEquals(29, p.parse("27+/*xxx*/ 2").evaluate(), EPSILON);
-        assertEquals(29, p.parse("27/*xxx*/+2").evaluate(), EPSILON);
+        assertEquals(29, parser.parse("27+ /*xxx*/ 2").evaluate(), EPSILON);
+        assertEquals(29, parser.parse("27+/*xxx*/ 2").evaluate(), EPSILON);
+        assertEquals(29, parser.parse("27/*xxx*/+2").evaluate(), EPSILON);
     }
 
     @Test
     public void startingWithDecimalPoint() throws ParseException {
-        assertEquals(.2, p.parse(".2").evaluate(), EPSILON);
-        assertEquals(.2, p.parse("+.2").evaluate(), EPSILON);
-        assertEquals(.4, p.parse(".2+.2").evaluate(), EPSILON);
-        assertEquals(.4, p.parse(".6+-.2").evaluate(), EPSILON);
+        assertEquals(.2, parser.parse(".2").evaluate(), EPSILON);
+        assertEquals(.2, parser.parse("+.2").evaluate(), EPSILON);
+        assertEquals(.4, parser.parse(".2+.2").evaluate(), EPSILON);
+        assertEquals(.4, parser.parse(".6+-.2").evaluate(), EPSILON);
     }
 
     @Test
     public void signedParentheses() throws ParseException {
-        assertEquals(0.2, p.parse("-(-0.2)").evaluate(), EPSILON);
-        assertEquals(1.2, p.parse("1-(-0.2)").evaluate(), EPSILON);
-        assertEquals(0.8, p.parse("1+(-0.2)").evaluate(), EPSILON);
-        assertEquals(2.2, p.parse("+(2.2)").evaluate(), EPSILON);
+        assertEquals(0.2, parser.parse("-(-0.2)").evaluate(), EPSILON);
+        assertEquals(1.2, parser.parse("1-(-0.2)").evaluate(), EPSILON);
+        assertEquals(0.8, parser.parse("1+(-0.2)").evaluate(), EPSILON);
+        assertEquals(2.2, parser.parse("+(2.2)").evaluate(), EPSILON);
     }
 
     @Test
     public void trailingDecimalPoint() throws ParseException {
-        assertEquals(2., p.parse("2.").evaluate(), EPSILON);
+        assertEquals(2., parser.parse("2.").evaluate(), EPSILON);
     }
 
     @Test
     public void signedValueAfterOperand() throws ParseException {
-        assertEquals(-1.2, p.parse("1+-2.2").evaluate(), EPSILON);
-        assertEquals(3.2, p.parse("1++2.2").evaluate(), EPSILON);
-        assertEquals(6 * -1.1, p.parse("6*-1.1").evaluate(), EPSILON);
-        assertEquals(6 * 1.1, p.parse("6*+1.1").evaluate(), EPSILON);
+        assertEquals(-1.2, parser.parse("1+-2.2").evaluate(), EPSILON);
+        assertEquals(3.2, parser.parse("1++2.2").evaluate(), EPSILON);
+        assertEquals(6 * -1.1, parser.parse("6*-1.1").evaluate(), EPSILON);
+        assertEquals(6 * 1.1, parser.parse("6*+1.1").evaluate(), EPSILON);
     }
 
     @Test
@@ -146,7 +150,7 @@ public class ParserTest {
 
         scope.create("a", 2);
         scope.create("b", 3);
-        Expression expr = p.parse("3*a + 4 * b", scope);
+        Expression expr = parser.parse("3*a + 4 * b", scope);
 
         assertEquals(18d, expr.evaluate(), EPSILON);
         assertEquals(18d, expr.evaluate(), EPSILON);
@@ -154,28 +158,26 @@ public class ParserTest {
 
     @Test
     public void functions() throws ParseException {
-        assertEquals(0d, p.parse("1 + sin(-pi) + cos(pi)").evaluate(), EPSILON);
-        assertEquals(4.72038341576d, p.parse("tan(sqrt(euler ^ (pi * 3)))").evaluate(), EPSILON);
-        assertEquals(3d, p.parse("| 3 - 6 |").evaluate(), EPSILON);
-        assertEquals(3d, p.parse("if(3 > 2 && 2 < 3, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(2d, p.parse("if(3 < 2 || 2 > 3, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(3d, p.parse("if(1, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(2d, p.parse("if(0, 2+1, 1+1)").evaluate(), EPSILON);
-        assertEquals(2d, p.parse("min(3,2)").evaluate(), EPSILON);
-        assertEquals(2d, p.parse("abs(2)").evaluate(), EPSILON);
-        assertEquals(2d, p.parse("abs(-2)").evaluate(), EPSILON);
-        assertEquals(-3d, p.parse("floor(-2.2)").evaluate(), EPSILON);
-        assertEquals(-2d, p.parse("ceil(-2.2)").evaluate(), EPSILON);
+        assertEquals(0d, parser.parse("1 + sin(-pi) + cos(pi)").evaluate(), EPSILON);
+        assertEquals(4.72038341576d, parser.parse("tan(sqrt(euler ^ (pi * 3)))").evaluate(), EPSILON);
+        assertEquals(3d, parser.parse("| 3 - 6 |").evaluate(), EPSILON);
+        assertEquals(3d, parser.parse("if(3 > 2 && 2 < 3, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(2d, parser.parse("if(3 < 2 || 2 > 3, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(3d, parser.parse("if(1, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(2d, parser.parse("if(0, 2+1, 1+1)").evaluate(), EPSILON);
+        assertEquals(2d, parser.parse("min(3,2)").evaluate(), EPSILON);
+        assertEquals(2d, parser.parse("abs(2)").evaluate(), EPSILON);
+        assertEquals(2d, parser.parse("abs(-2)").evaluate(), EPSILON);
+        assertEquals(-3d, parser.parse("floor(-2.2)").evaluate(), EPSILON);
+        assertEquals(-2d, parser.parse("ceil(-2.2)").evaluate(), EPSILON);
 
-        Scope scope = new Scope();
-        scope.addInvocationVariable("x");
-        assertEquals(1d, p.parse("if(x, 0, 1)", scope).evaluate(0), EPSILON);
-        assertEquals(0d, p.parse("if(x, 0, 1)", scope).evaluate(10), EPSILON);
+        assertEquals(1d, parser.parse("if(x, 0, 1)", singleVariableScope).evaluate(0), EPSILON);
+        assertEquals(0d, parser.parse("if(x, 0, 1)", singleVariableScope).evaluate(10), EPSILON);
 
 
         // Test a var arg method...
-        p.registerFunction("avg", avgFun);
-        assertEquals(3.25d, p.parse("avg(3,2,1,7)").evaluate(), EPSILON);
+        parser.registerFunction("avg", avgFun);
+        assertEquals(3.25d, parser.parse("avg(3,2,1,7)").evaluate(), EPSILON);
     }
 
     DynamicFunction avgFun = new DynamicFunction() {
@@ -226,8 +228,8 @@ public class ParserTest {
         root.create("d", 9);
         subScope1.create("d", 7);
 
-        Expression expr1 = p.parse("a + b + c + d", subScope1);
-        Expression expr2 = p.parse("a + b + c + d", subScope2);
+        Expression expr1 = parser.parse("a + b + c + d", subScope1);
+        Expression expr2 = parser.parse("a + b + c + d", subScope2);
         assertEquals(15d, expr1.evaluate(), EPSILON);
         assertEquals(17d, expr2.evaluate(), EPSILON);
     }
@@ -236,7 +238,7 @@ public class ParserTest {
     public void errors() {
         // We expect the parser to continue after an recoverable error!
         try {
-            p.parse("test(1 2)+sin(1,2)*34-34.45.45+");
+            parser.parse("test(1 2)+sin(1,2)*34-34.45.45+");
             fail();
         } catch (ParseException e) {
             assertEquals(5, e.getErrors().size());
@@ -244,7 +246,7 @@ public class ParserTest {
 
         // We expect the parser to report an invalid quantifier.
         try {
-            p.parse("1x");
+            parser.parse("1x");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -252,7 +254,7 @@ public class ParserTest {
 
         // We expect the parser to report an unfinished expression
         try {
-            p.parse("1(");
+            parser.parse("1(");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -260,7 +262,7 @@ public class ParserTest {
 
         // We expect the parser to report an unexpected separator.
         try {
-            p.parse("3ee3");
+            parser.parse("3ee3");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -268,7 +270,7 @@ public class ParserTest {
 
         // We expect the parser to report an unexpected separator.
         try {
-            p.parse("3e3.3");
+            parser.parse("3e3.3");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -276,7 +278,7 @@ public class ParserTest {
 
         // We expect the parser to report an unexpected token.
         try {
-            p.parse("3e");
+            parser.parse("3e");
             fail();
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
@@ -286,19 +288,19 @@ public class ParserTest {
     @Test
     public void relationalOperators() throws ParseException {
         // Test for Issue with >= and <= operators (#4)
-        assertEquals(1d, p.parse("5 <= 5").evaluate(), EPSILON);
-        assertEquals(1d, p.parse("5 >= 5").evaluate(), EPSILON);
-        assertEquals(0d, p.parse("5 < 5").evaluate(), EPSILON);
-        assertEquals(0d, p.parse("5 > 5").evaluate(), EPSILON);
+        assertEquals(1d, parser.parse("5 <= 5").evaluate(), EPSILON);
+        assertEquals(1d, parser.parse("5 >= 5").evaluate(), EPSILON);
+        assertEquals(0d, parser.parse("5 < 5").evaluate(), EPSILON);
+        assertEquals(0d, parser.parse("5 > 5").evaluate(), EPSILON);
     }
 
     @Test
     public void quantifiers() throws ParseException {
-        assertEquals(1000d, p.parse("1K").evaluate(), EPSILON);
-        assertEquals(1000d, p.parse("1M * 1m").evaluate(), EPSILON);
-        assertEquals(1d, p.parse("1n * 1G").evaluate(), EPSILON);
-        assertEquals(1d, p.parse("(1M / 1k) * 1m").evaluate(), EPSILON);
-        assertEquals(1d, p.parse("1u * 10 k * 1000  m * 0.1 k").evaluate(), EPSILON);
+        assertEquals(1000d, parser.parse("1K").evaluate(), EPSILON);
+        assertEquals(1000d, parser.parse("1M * 1m").evaluate(), EPSILON);
+        assertEquals(1d, parser.parse("1n * 1G").evaluate(), EPSILON);
+        assertEquals(1d, parser.parse("(1M / 1k) * 1m").evaluate(), EPSILON);
+        assertEquals(1d, parser.parse("1u * 10 k * 1000  m * 0.1 k").evaluate(), EPSILON);
     }
 
     @Test
@@ -307,13 +309,13 @@ public class ParserTest {
         try {
             s.create("a", 0);
             s.create("b", 0);
-            p.parse("a*b+c", s);
+            parser.parse("a*b+c", s);
         } catch (ParseException e) {
             assertEquals(1, e.getErrors().size());
         }
 
         s.create("c", 0);
-        p.parse("a*b+c", s);
+        parser.parse("a*b+c", s);
     }
 
     @Test


### PR DESCRIPTION
Cleans up buildscripts, tests, and benchmarks

- Add nyx gradle plugin
- Enable publishing of javadoc & sources jar
- Add solo-studios maven repo (can be removed if desired)
- Update benchmarks
  - Test additional expressions
  - Use longer test time for more reliable results
  - Update README with new benchmark run
- Upgrade to JUnit 5

Fixes #9 